### PR TITLE
Add turborepo instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Everything is still a little early, so please add comments to our user guide if 
 
 We *do not* consistently check GH issues — if you have any questions or issues, reach out to us on our [Community Slack server](https://join.slack.com/t/graphite-community/shared_invite/zt-1as9rdo7r-pYmEZzt6M1EhTkvJFNhsnQ)!
 
+
 ## Developing and Running tests
 
 Interested in contributing to graphite CLI? Here's how to get started.
@@ -35,6 +36,17 @@ You'll need to install yarn on your machine
 
 ```
 npm install --global yarn
+```
+
+You'll also need to install turbo
+```
+npm install --global turbo
+```
+
+Build the monorepo
+```
+yarn install
+turbo run build
 ```
 
 Build the CLI


### PR DESCRIPTION
**Context:**

contribution instructions in the readme don't explain how to build with turbo, the existing instructions you'd have build errors on the cli

**Changes In This Pull Request:**

**Test Plan:**
