### PR TITLE
feat: add --automerge and --browser flags

### DIFF
--- a/apps/cli/src/actions/submit/prepare_branches.ts
+++ b/apps/cli/src/actions/submit/prepare_branches.ts
@@ -39,6 +39,8 @@ export async function getPRInfoForBranches(
     reviewers: string | undefined;
     select: boolean;
     always: boolean;
+    automerge: boolean;
+    browser: boolean;
   },
   context: TContext
 ): Promise<TPRSubmissionInfo> {
@@ -54,6 +56,8 @@ export async function getPRInfoForBranches(
         select: args.select,
         editPRFieldsInline: args.editPRFieldsInline,
         always: args.always,
+        automerge: args.automerge,
+        browser: args.browser,
       },
       context
     );
@@ -76,6 +80,7 @@ export async function getPRInfoForBranches(
               draft: args.draft,
               publish: args.publish,
               reviewers: args.reviewers,
+              automerge: args.automerge,
             },
             context
           )
@@ -84,6 +89,7 @@ export async function getPRInfoForBranches(
             body: '',
             reviewers: [],
             draft: false,
+            automerge: false,
           };
 
     submissionInfo.push({
@@ -102,6 +108,7 @@ export async function getPRInfoForBranches(
                 draft: args.draft,
                 publish: args.publish,
                 reviewers: args.reviewers,
+                automerge: args.automerge,
               },
               context
             )),
@@ -126,6 +133,8 @@ async function getPRAction(
     always: boolean;
     select: boolean;
     editPRFieldsInline: boolean | undefined;
+    automerge: boolean;
+    browser: boolean;
   },
   context: TContext
 ): Promise<TPRSubmissionAction | undefined> {
@@ -185,6 +194,7 @@ async function getPRCreationInfo(
     draft: boolean;
     publish: boolean;
     reviewers: string | undefined;
+    automerge: boolean;
   },
   context: TContext
 ): Promise<{
@@ -192,6 +202,7 @@ async function getPRCreationInfo(
   body: string;
   reviewers: string[];
   draft: boolean;
+  automerge: boolean;
 }> {
   if (args.editPRFieldsInline) {
     context.splog.newline();
@@ -243,6 +254,7 @@ async function getPRCreationInfo(
     body: submitInfo.body,
     reviewers,
     draft: createAsDraft,
+    automerge: args.automerge,
   };
 }
 
@@ -253,6 +265,7 @@ async function getPRUpdateInfo(
     draft: boolean;
     publish: boolean;
     reviewers: string | undefined;
+    automerge: boolean;
   },
   context: TContext
 ): Promise<{
@@ -260,6 +273,7 @@ async function getPRUpdateInfo(
   body?: string;
   reviewers: string[];
   draft: boolean | undefined;
+  automerge: boolean;
 }> {
   const submitInfo: TBranchPRInfo = {};
   if (args.editPRFieldsInline) {
@@ -307,6 +321,7 @@ async function getPRUpdateInfo(
     body: submitInfo.body,
     reviewers,
     draft,
+    automerge: args.automerge,
   };
 }
 

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -28,6 +28,8 @@ export async function submitAction(
     select: boolean;
     always: boolean;
     branch: string | undefined;
+    automerge: boolean;
+    browser: boolean;
   },
   context: TContext
 ): Promise<void> {
@@ -95,6 +97,8 @@ export async function submitAction(
       dryRun: args.dryRun,
       select: args.select,
       always: args.always,
+      automerge: args.automerge,
+      browser: args.browser,
     },
     context
   );
@@ -133,7 +137,10 @@ export async function submitAction(
       throw err;
     }
 
-    await submitPullRequest([submissionInfo], context);
+    await submitPullRequest([submissionInfo], context, {
+      automerge: args.automerge,
+      browser: args.browser,
+    });
   }
 
   context.splog.info(

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -23,7 +23,8 @@ type TSubmittedPR = {
 
 export async function submitPullRequest(
   submissionInfo: TPRSubmissionInfo,
-  context: TContext
+  context: TContext,
+  options?: { automerge?: boolean; browser?: boolean }
 ): Promise<void> {
   const pr = await requestServerToSubmitPR({
     submissionInfo,
@@ -49,6 +50,62 @@ export async function submitPullRequest(
       : {}),
     ...(pr.request.draft !== undefined ? { draft: pr.request.draft } : {}),
   });
+
+  // Enable automerge if requested
+  if (options?.automerge && pr.response.prNumber) {
+    try {
+      execFileSync('gh', [
+        'pr',
+        'merge',
+        pr.response.prNumber.toString(),
+        '--auto',
+        '--squash',
+      ]);
+      context.splog.info(
+        `${chalk.green('✓')} Automerge enabled for ${chalk.cyan(
+          pr.response.head
+        )}`
+      );
+    } catch (error) {
+      context.splog.warn(
+        `Failed to enable automerge for ${chalk.cyan(pr.response.head)}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+
+  // Open in browser if requested
+  if (options?.browser && pr.response.prURL) {
+    try {
+      const platform = process.platform;
+      let openCommand: string;
+
+      switch (platform) {
+        case 'darwin': // macOS
+          openCommand = 'open';
+          break;
+        case 'win32': // Windows
+          openCommand = 'start';
+          break;
+        default: // Linux and others
+          openCommand = 'xdg-open';
+          break;
+      }
+
+      execFileSync(openCommand, [pr.response.prURL]);
+      context.splog.info(
+        `${chalk.green('🌐')} Opened ${chalk.cyan(pr.response.head)} in browser`
+      );
+    } catch (error) {
+      context.splog.warn(
+        `Failed to open ${chalk.cyan(pr.response.head)} in browser: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+
   context.splog.info(
     `${chalk.green(pr.response.head)}: ${pr.response.prURL} (${{
       updated: chalk.yellow,

--- a/apps/cli/src/commands/branch-commands/submit.ts
+++ b/apps/cli/src/commands/branch-commands/submit.ts
@@ -34,6 +34,8 @@ export const handler = async (argv: argsT): Promise<void> => {
         select: argv.select,
         always: argv.always,
         branch: argv.branch,
+        automerge: argv.automerge,
+        browser: argv.browser,
       },
       context
     );

--- a/apps/cli/src/commands/downstack-commands/submit.ts
+++ b/apps/cli/src/commands/downstack-commands/submit.ts
@@ -24,6 +24,8 @@ export const handler = async (argv: argsT): Promise<void> => {
         select: argv.select,
         always: argv.always,
         branch: argv.branch,
+        automerge: argv.automerge,
+        browser: argv.browser,
       },
       context
     );

--- a/apps/cli/src/commands/shared-commands/submit.ts
+++ b/apps/cli/src/commands/shared-commands/submit.ts
@@ -98,6 +98,18 @@ export const args = {
     describe: 'Which branch to run this command from (default: current branch)',
     type: 'string',
   },
+  automerge: {
+    describe: 'Enable automerge on the pull request(s)',
+    type: 'boolean',
+    default: false,
+    alias: 'a',
+  },
+  browser: {
+    describe: 'Open the pull request(s) in the browser when finished',
+    type: 'boolean',
+    default: false,
+    alias: 'b',
+  },
 } as const;
 
 export const builder = args;

--- a/apps/cli/src/commands/stack-commands/submit.ts
+++ b/apps/cli/src/commands/stack-commands/submit.ts
@@ -24,6 +24,8 @@ export const handler = async (argv: argsT): Promise<void> => {
         select: argv.select,
         always: argv.always,
         branch: argv.branch,
+        automerge: argv.automerge,
+        browser: argv.browser,
       },
       context
     );

--- a/apps/cli/src/commands/upstack-commands/submit.ts
+++ b/apps/cli/src/commands/upstack-commands/submit.ts
@@ -34,6 +34,8 @@ export const handler = async (argv: argsT): Promise<void> => {
         select: argv.select,
         always: argv.always,
         branch: argv.branch,
+        automerge: argv.automerge,
+        browser: argv.browser,
       },
       context
     );

--- a/apps/cli/test/actions/submit/prepare_branches.test.ts
+++ b/apps/cli/test/actions/submit/prepare_branches.test.ts
@@ -52,6 +52,8 @@ describe(`(${scene}): correctly get PR information for branches`, function () {
           reviewers: undefined,
           select: false,
           always: false,
+          automerge: false,
+          browser: false,
         },
         context
       )


### PR DESCRIPTION
**Context:** I usually set up automerge and open the PR right after creating it, so i'd rather have that done automatically

**Changes In This Pull Request:** Added `--automerge` and `--browser` flags for `gt branch submit` command amongst others.

**Test Plan:** Try submitting a new branch using `--automerge` and `--browser` and see both the PR having been set to automerge and it opened in the browser.
