### PR TITLE
fix: use gh api instead of gh pr edit to avoid Projects deprecation error

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -11,7 +11,7 @@ import {
   footerFooter,
   footerTitle,
 } from '../create_pr_body_footer';
-import { execFileSync } from 'child_process';
+import { updatePullRequest } from '../../lib/git/gh_pr_edit';
 
 // eslint-disable-next-line max-lines-per-function
 export async function submitAction(
@@ -144,20 +144,16 @@ export async function submitAction(
     const prInfo = context.engine.getPrInfo(branch);
     const footer = createPrBodyFooter(context, branch);
 
-    if (!prInfo) {
+    if (!prInfo || prInfo.number === undefined) {
       throw new Error(`PR info is undefined for branch ${branch}`);
     }
 
     const prFooterChanged = !prInfo.body?.includes(footer);
 
     if (prFooterChanged) {
-      execFileSync('gh', [
-        'pr',
-        'edit',
-        `${prInfo.number}`,
-        '--body',
-        updatePrBodyFooter(prInfo.body, footer),
-      ]);
+      updatePullRequest(prInfo.number, {
+        body: updatePrBodyFooter(prInfo.body, footer),
+      });
 
       context.splog.info(
         `${chalk.green(branch)}: ${prInfo.url} (${

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -5,6 +5,7 @@ import { TContext } from '../../lib/context';
 import { ExitFailedError } from '../../lib/errors';
 import { Unpacked } from '../../lib/utils/ts_helpers';
 import { execFileSync } from 'child_process';
+import { updatePullRequest } from '../../lib/git/gh_pr_edit';
 
 export type TPRSubmissionInfo = t.UnwrapSchemaMap<
   typeof API_ROUTES.submitPullRequests.params
@@ -110,13 +111,7 @@ async function submitPrToGithub({
     const prBaseChanged = prInfo.baseRefName !== request.base;
 
     if (prBaseChanged) {
-      execFileSync('gh', [
-        'pr',
-        'edit',
-        prInfo.headRefName,
-        '--base',
-        request.base,
-      ]);
+      updatePullRequest(prInfo.number, { base: request.base });
     }
 
     return {

--- a/apps/cli/src/lib/git/gh_pr_edit.ts
+++ b/apps/cli/src/lib/git/gh_pr_edit.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from 'child_process';
+
+/**
+ * Updates a PR's fields using either `gh api` (default) or `gh pr edit` (legacy).
+ *
+ * By default, uses `gh api` to avoid GitHub CLI bug with Projects (classic)
+ * deprecation error: https://github.com/cli/cli/issues/11983
+ *
+ * Set GT_USE_GH_PR_EDIT=1 to use the legacy `gh pr edit` command instead.
+ */
+export function updatePullRequest(
+  prNumber: number,
+  fields: { base?: string; body?: string }
+): void {
+  if (process.env.GT_USE_GH_PR_EDIT) {
+    // Legacy behavior using gh pr edit
+    const args = ['pr', 'edit', `${prNumber}`];
+    if (fields.base !== undefined) {
+      args.push('--base', fields.base);
+    }
+    if (fields.body !== undefined) {
+      args.push('--body', fields.body);
+    }
+    execFileSync('gh', args);
+  } else {
+    // Use gh api to avoid Projects (classic) deprecation error
+    const args = [
+      'api',
+      '--method',
+      'PATCH',
+      `/repos/{owner}/{repo}/pulls/${prNumber}`,
+    ];
+    if (fields.base !== undefined) {
+      args.push('-f', `base=${fields.base}`);
+    }
+    if (fields.body !== undefined) {
+      args.push('-f', `body=${fields.body}`);
+    }
+    execFileSync('gh', args);
+  }
+}


### PR DESCRIPTION
GitHub CLI's `gh pr edit` command fails with a GraphQL error about Projects (classic) deprecation even when not using project flags. This is a known bug: https://github.com/cli/cli/issues/11983

While upgrading gh CLI may fix this for some users, it doesn't work for all (still occurs on gh 2.83.1). This provides a reliable workaround by using the REST API via 'gh api' instead.

Set GT_USE_GH_PR_EDIT=1 to revert to the legacy gh pr edit behavior.

Fixes #117