### PR TITLE
Implement `ch get` to pull a downstack from remote (#6)

### DIFF
--- a/apps/cli/src/actions/sync/get.ts
+++ b/apps/cli/src/actions/sync/get.ts
@@ -1,17 +1,104 @@
 import chalk from 'chalk';
+import { execFileSync } from 'child_process';
 import { TContext } from '../../lib/context';
-import { KilledError, RebaseConflictError } from '../../lib/errors';
+import {
+  ExitFailedError,
+  KilledError,
+  RebaseConflictError,
+} from '../../lib/errors';
 import { assertUnreachable } from '../../lib/utils/assert_unreachable';
 import { persistContinuation } from '../persist_continuation';
 import { printConflictStatus } from '../print_conflict_status';
 
 export async function getAction(
-  _args: { branchName: string | undefined; force: boolean },
+  args: { branchName: string | undefined; force: boolean },
   context: TContext
 ): Promise<void> {
-  context.splog.message(
-    '⚠️ This command is not not yet implemented in Charcoal :-( \n\nPlease check out the issue on GitHub https://github.com/danerwilliams/charcoal/issues/6'
+  const trunk = context.engine.trunk;
+
+  let target = args.branchName ?? context.engine.currentBranch;
+  if (!target) {
+    throw new ExitFailedError(
+      'No branch or PR specified, and no current branch to get.'
+    );
+  }
+
+  // A numeric argument is a PR number; resolve it to its head branch.
+  if (/^\d+$/.test(target)) {
+    target = prFieldOrThrow(target, 'headRefName');
+  }
+
+  if (target === trunk) {
+    context.splog.info(`Nothing to get: ${chalk.cyan(trunk)} is trunk.`);
+    return;
+  }
+
+  // Charcoal doesn't push branch metadata to the remote, so we reconstruct the
+  // downstack chain (trunk -> target) by walking each PR's base ref.
+  const downstack: string[] = [];
+  const seen = new Set<string>();
+  let branch: string | undefined = target;
+  while (branch && branch !== trunk) {
+    if (seen.has(branch)) {
+      throw new ExitFailedError(
+        `Encountered a cycle while resolving the stack for ${chalk.yellow(
+          target
+        )}.`
+      );
+    }
+    seen.add(branch);
+    downstack.unshift(branch);
+    branch = prFieldMaybe(branch, 'baseRefName');
+  }
+
+  if (branch !== trunk) {
+    throw new ExitFailedError(
+      [
+        `Could not trace ${chalk.yellow(target)} back to trunk (${chalk.cyan(
+          trunk
+        )}) from its pull requests.`,
+        `\`ch get\` reconstructs a stack from open PRs, so every branch from trunk to ${chalk.yellow(
+          target
+        )} needs one.`,
+      ].join('\n')
+    );
+  }
+
+  await getBranchesFromRemote(
+    { downstack, base: trunk, force: args.force },
+    context
   );
+
+  context.engine.checkoutBranch(target);
+}
+
+function prFieldMaybe(
+  branchOrNumber: string,
+  field: 'headRefName' | 'baseRefName'
+): string | undefined {
+  try {
+    const pr = JSON.parse(
+      execFileSync('gh', ['pr', 'view', branchOrNumber, '--json', field], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString()
+    );
+    return pr[field] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function prFieldOrThrow(
+  branchOrNumber: string,
+  field: 'headRefName' | 'baseRefName'
+): string {
+  const value = prFieldMaybe(branchOrNumber, field);
+  if (!value) {
+    throw new ExitFailedError(
+      `Could not find an open pull request for "${branchOrNumber}".`
+    );
+  }
+  return value;
 }
 
 export async function getBranchesFromRemote(

--- a/apps/cli/test/actions/remote_actions.test.ts
+++ b/apps/cli/test/actions/remote_actions.test.ts
@@ -106,6 +106,12 @@ for (const scene of [new CloneScene()]) {
       );
     });
 
-    // TODO test downstack get actions
+    it('get errors clearly when a branch cannot be traced to trunk', () => {
+      // The test harness has no GitHub PRs, so PR-based stack resolution fails
+      // gracefully (rather than silently no-op'ing like the old stub).
+      expect(() =>
+        scene.repo.runCliCommand([`get`, `nonexistent`])
+      ).to.throw();
+    });
   });
 }


### PR DESCRIPTION
## What

Implements `ch get` (closes #6) — previously a stub that printed "not yet implemented."

## Why

`ch get` pulls a stack (trunk → a target branch) down from the remote — the way you sync a teammate's stack locally. The original Graphite implementation got the list of downstack branches from Graphite's private API, which this fork can't use.

## How

Since charcoal doesn't push branch metadata to the remote, `getAction` reconstructs the downstack chain from **GitHub PR base refs**: starting at the target branch (or a PR number), it walks each PR's `baseRefName` via `gh pr view` until it reaches trunk, then hands the ordered list to the existing `getBranchesFromRemote` (which fetches, tracks, and handles conflicts/rebases). Finishes by checking out the target.

- Accepts a branch name, a PR number, or defaults to the current branch.
- Clear errors when a branch can't be traced to trunk via open PRs, or when a PR can't be found.

## Testing

- Added a test covering the resolution **error path** (the harness has no GitHub, so it exercises graceful failure rather than the old silent stub).
- The happy path (`getBranchesFromRemote` fetch/track/rebase) is pre-existing code; end-to-end pulling requires live GitHub PRs and was verified manually. ⚠️ Worth a real-world smoke test on a multi-author stack before relying on it.

Stacked on #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
