### PR TITLE
Fix submit: --update-only crash, --reviewers, parent dep-tree (#109 #114 #85)

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -140,14 +140,27 @@ export async function submitAction(
     chalk.blueBright('\n🌳 Updating dependency trees in PR bodies...')
   );
 
+  // Submitting changes the dependency tree of the submitted branches *and*
+  // their ancestors, so refresh footers for both (#85).
+  const branchesToUpdate = new Set<string>(branchNames);
   for (const branch of branchNames) {
-    const prInfo = context.engine.getPrInfo(branch);
-    const footer = createPrBodyFooter(context, branch);
+    let ancestor = context.engine.getParent(branch);
+    while (ancestor && !context.engine.isTrunk(ancestor)) {
+      branchesToUpdate.add(ancestor);
+      ancestor = context.engine.getParent(ancestor);
+    }
+  }
 
-    if (!prInfo) {
-      throw new Error(`PR info is undefined for branch ${branch}`);
+  for (const branch of branchesToUpdate) {
+    const prInfo = context.engine.getPrInfo(branch);
+
+    // A branch with no open PR (e.g. an unsubmitted leaf under --update-only)
+    // has no body to update; skip it rather than `gh pr edit undefined` (#109).
+    if (!prInfo?.number) {
+      continue;
     }
 
+    const footer = createPrBodyFooter(context, branch);
     const prFooterChanged = !prInfo.body?.includes(footer);
 
     if (prFooterChanged) {
@@ -160,9 +173,7 @@ export async function submitAction(
       ]);
 
       context.splog.info(
-        `${chalk.green(branch)}: ${prInfo.url} (${
-          prFooterChanged ? chalk.yellow('Updated') : 'No-op'
-        })`
+        `${chalk.green(branch)}: ${prInfo.url} (${chalk.yellow('Updated')})`
       );
     }
   }

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -90,6 +90,9 @@ async function submitPrToGithub({
 }: {
   request: TSubmittedPRRequest;
 }): Promise<TSubmittedPRResponse> {
+  // prepare_branches always attaches reviewers, but the route type only
+  // declares them on the 'create' variant.
+  const reviewers = (request as { reviewers?: string[] }).reviewers ?? [];
   try {
     const prInfo = await JSON.parse(
       execFileSync('gh', [
@@ -109,14 +112,13 @@ async function submitPrToGithub({
 
     const prBaseChanged = prInfo.baseRefName !== request.base;
 
-    if (prBaseChanged) {
-      execFileSync('gh', [
-        'pr',
-        'edit',
-        prInfo.headRefName,
-        '--base',
-        request.base,
-      ]);
+    const editArgs = [
+      ...(prBaseChanged ? ['--base', request.base] : []),
+      ...reviewers.flatMap((r) => ['--add-reviewer', r]),
+    ];
+
+    if (editArgs.length) {
+      execFileSync('gh', ['pr', 'edit', prInfo.headRefName, ...editArgs]);
     }
 
     return {
@@ -142,6 +144,7 @@ async function submitPrToGithub({
         '--body',
         request.body ?? '',
         ...(request.draft ? ['--draft'] : []),
+        ...reviewers.flatMap((r) => ['--reviewer', r]),
       ])
         .toString()
         .trim();


### PR DESCRIPTION
## What

Three submit bug fixes:

- **#109** — `ch submit --update-only` crashed (`gh pr edit undefined`) when a branch in the stack had no open PR.
- **#114** — `--reviewers` was parsed but never passed to `gh`, so it set no reviewers.
- **#85** — parent PRs' embedded dependency tree didn't refresh when the stack changed.

## How

**#109 + #85** (`submit_action.ts`, the "Updating dependency trees" loop):
- Now also refreshes the footers of the submitted branches' **ancestors** (their dependency tree changed too) — fixes #85.
- Skips any branch with no PR number instead of throwing / running `gh pr edit undefined` — fixes #109.

**#114** (`submit_prs.ts`):
- `gh pr create` now passes `--reviewer` for each reviewer; `gh pr edit` passes `--add-reviewer`. Reviewers are read with a localized cast because `prepare_branches` attaches them at runtime but the route type only declares them on the `create` variant.

## Testing

- Build + typecheck clean; all existing submit/reviewers tests pass (no regression).
- ⚠️ These code paths only run after a successful `gh pr view`/`create`, which the local test harness (and CI) can't reach — so the fixes are logic-verified and need a **live-GitHub smoke test**: submit a stack with `--reviewers`, an unsubmitted leaf under `--update-only`, and confirm parent PR bodies refresh.

Stacked on #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
