### PR TITLE
Build standalone binaries with Bun instead of pkg

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,6 +33,24 @@ jobs:
       - name: Test
         run: yarn workspace @danerwilliams/charcoal run test-ci
 
+  binary:
+    name: 'Build binary (smoke test)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+      - uses: oven-sh/setup-bun@v2
+      - name: Install
+        run: yarn install --immutable
+      - name: Build
+        run: yarn turbo run build
+      - name: Compile and smoke test the binary
+        working-directory: apps/cli
+        run: |
+          bun build --compile ./dist/src/index.js --outfile ch
+          ./ch --version
+          ./ch fish | head -1
+
   superlinter:
     name: 'Run superlinter'
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,38 +55,36 @@ jobs:
           TYPESCRIPT_DEFAULT_STYLE: prettier
 
   create-binaries:
-    name: Upload executable binaries
-    strategy:
-      matrix:
-        include:
-          - runner: macos-latest
-            target: node18-macos-x64
-            name: ch-macos-x64
-          - runner: macos-latest
-            target: node18-macos-arm64
-            name: ch-macos-arm64
-          - runner: ubuntu-latest
-            target: node18-linux
-            name: ch-linux
-    runs-on: ${{ matrix.runner }}
+    name: Build release binaries
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
       - name: Install
         run: yarn install --immutable
       - name: Build
         run: yarn turbo run build
-      - name: Build binary
-        run: yarn workspace @danerwilliams/charcoal run build-pkg -t ${{ matrix.target }} -o "${{ matrix.name }}-${{ github.sha }}"
-      - name: Upload binary
+      # Bun cross-compiles every target from this single Linux runner.
+      - name: Build binaries
+        working-directory: apps/cli
+        run: |
+          bun build --compile --target=bun-darwin-arm64 ./dist/src/index.js --outfile ch-macos-arm64
+          bun build --compile --target=bun-darwin-x64 ./dist/src/index.js --outfile ch-macos-x64
+          bun build --compile --target=bun-linux-x64 ./dist/src/index.js --outfile ch-linux
+      - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}-${{ github.sha }}
-          path: apps/cli/${{ matrix.name }}-${{ github.sha }}
+          name: ch-binaries-${{ github.sha }}
+          path: |
+            apps/cli/ch-macos-arm64
+            apps/cli/ch-macos-x64
+            apps/cli/ch-linux
 
   release:
     name: Release version
@@ -94,23 +92,10 @@ jobs:
     needs: [lint_and_fast_tests, create-binaries]
     runs-on: ubuntu-latest
     steps:
-      - name: Download macOS arm64
+      - name: Download binaries
         uses: actions/download-artifact@v4
         with:
-          name: ch-macos-arm64-${{ github.sha }}
-      - name: Download macOS x64
-        uses: actions/download-artifact@v4
-        with:
-          name: ch-macos-x64-${{ github.sha }}
-      - name: Download Linux
-        uses: actions/download-artifact@v4
-        with:
-          name: ch-linux-${{ github.sha }}
-      - name: Rename files
-        run: |
-          mv ch-macos-arm64-${{ github.sha }} ch-macos-arm64;
-          mv ch-macos-x64-${{ github.sha }} ch-macos-x64;
-          mv ch-linux-${{ github.sha }} ch-linux
+          name: ch-binaries-${{ github.sha }}
       - name: Release
         uses: ncipollo/release-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,13 +76,16 @@ ch <command>
 
 ## Release Binaries
 
-The release workflow builds all three binaries automatically on a `v*` tag:
-`ch-macos-arm64`, `ch-macos-x64`, and `ch-linux`.
+Binaries are standalone executables compiled with [Bun](https://bun.sh)
+(`bun build --compile`). The release workflow cross-compiles all three from a
+single Linux runner on a `v*` tag: `ch-macos-arm64`, `ch-macos-x64`, and
+`ch-linux`.
 
-To build one locally (from the cli app directory), e.g. the macOS ARM binary:
+To build one locally (requires `bun`; from the cli app directory after
+`yarn build`), e.g. the macOS ARM binary:
 
 ```
-yarn build-pkg -t node18-macos-arm64 -o ch-macos-arm64
+yarn build-binary --target=bun-darwin-arm64 --outfile ch-macos-arm64
 ```
 
 ## Getting Hashes for the Homebrew Tap

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,18 +20,6 @@
     "tmp": "^0.2.1",
     "yargs": "^17.5.1"
   },
-  "pkg": {
-    "scripts": "dist/src/**/*.js",
-    "assets": [
-      "dist/src/commands/**/*",
-      "dist/src/lib/ch.fish"
-    ],
-    "targets": [
-      "node18-macos",
-      "node18-linux"
-    ],
-    "outputPath": "pkg"
-  },
   "publishConfig": {
     "access": "public"
   },
@@ -40,8 +28,8 @@
     "postinstall": "node scripts/node_version.js || node dist/scripts/node_version.js",
     "lint": "eslint src --quiet --ext .ts --cache",
     "check": "tsc --noEmit",
-    "build": "rm -rf dist/ && yarn lint && tsc && cp scripts/node_version.js dist/scripts/node_version.js && cp src/lib/ch.fish dist/src/lib/ch.fish",
-    "build-pkg": "pkg dist/src/index.js -c package.json --public-packages \"*\"",
+    "build": "rm -rf dist/ && yarn lint && tsc && cp scripts/node_version.js dist/scripts/node_version.js",
+    "build-binary": "bun build --compile ./dist/src/index.js",
     "dev": "./scripts/installation/develop.sh",
     "cli": "node ./dist/src/index.js",
     "test": "tsc && yarn mocha \"dist/test/**/*.test.js\"  --parallel --jobs 8",
@@ -83,7 +71,6 @@
     "nock": "^13.2.6",
     "nyc": "^15.1.0",
     "pinst": "^3.0.0",
-    "pkg": "^5.8.1",
     "prettier": "^2.8.3",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3"

--- a/apps/cli/src/commands/completion.ts
+++ b/apps/cli/src/commands/completion.ts
@@ -1,19 +1,21 @@
-import yargs, { Arguments } from 'yargs';
+import { Argv, Arguments } from 'yargs';
 import { composeGit } from '../lib/git/git';
 
-yargs.completion(
-  'completion',
-  'Set up bash or zsh tab completion.',
-  //@ts-expect-error types/yargs is out of date with yargs
-  // eslint-disable-next-line max-params
-  (current, argv, defaultCompletion, done) => {
-    return shouldCompleteBranch(current, argv)
-      ? // we don't want to load a full context here, so we'll just use the git call directly
-        // once we persist the meta cache to disk, we can consider using a context here
-        done(Object.keys(composeGit().getBranchNamesAndRevisions()))
-      : defaultCompletion();
-  }
-);
+export function registerCompletion(yargs: Argv): Argv {
+  return yargs.completion(
+    'completion',
+    'Set up bash or zsh tab completion.',
+    //@ts-expect-error types/yargs is out of date with yargs
+    // eslint-disable-next-line max-params
+    (current, argv, defaultCompletion, done) => {
+      return shouldCompleteBranch(current, argv)
+        ? // we don't want to load a full context here, so we'll just use the git call directly
+          // once we persist the meta cache to disk, we can consider using a context here
+          done(Object.keys(composeGit().getBranchNamesAndRevisions()))
+        : defaultCompletion();
+    }
+  );
+}
 
 const BRANCH_COMPLETING_COMMANDS = [
   'checkout',

--- a/apps/cli/src/commands/dev.ts
+++ b/apps/cli/src/commands/dev.ts
@@ -1,13 +1,11 @@
-import yargs from 'yargs';
+import { Argv } from 'yargs';
+import { registerCommands } from '../lib/register_commands';
+import * as cache from './dev-commands/cache';
+import * as meta from './dev-commands/meta';
 
 export const command = 'dev <command>';
 export const description = false;
 
-export const builder = function (yargs: yargs.Argv): yargs.Argv {
-  return yargs
-    .commandDir('dev-commands', {
-      extensions: ['js'],
-    })
-    .strict()
-    .demandCommand();
+export const builder = function (yargs: Argv): Argv {
+  return registerCommands(yargs, [cache, meta]).strict().demandCommand();
 };

--- a/apps/cli/src/commands/feedback.ts
+++ b/apps/cli/src/commands/feedback.ts
@@ -1,12 +1,11 @@
-import yargs from 'yargs';
+import { Argv } from 'yargs';
+import { registerCommands } from '../lib/register_commands';
+import * as debugContext from './feedback-commands/debug_context';
 
 export const command = 'feedback <command>';
 export const desc = 'Commands for providing feedback and debug state.';
-export const builder = function (yargs: yargs.Argv): yargs.Argv {
-  return yargs
-    .commandDir('feedback-commands', {
-      extensions: ['js'],
-    })
+export const builder = function (yargs: Argv): Argv {
+  return registerCommands(yargs, [debugContext])
     .strict()
     .showHelpOnFail(false, `Use 'ch feedback --help' for usage`);
 };

--- a/apps/cli/src/commands/fish.ts
+++ b/apps/cli/src/commands/fish.ts
@@ -1,7 +1,6 @@
-import fs from 'fs-extra';
 import yargs from 'yargs';
 
-import path from 'path';
+import { FISH_COMPLETION } from '../lib/fish_completion';
 import { graphiteWithoutRepo } from '../lib/runner';
 const args = {} as const;
 
@@ -14,9 +13,5 @@ export const description = 'Set up fish tab completion.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> =>
   graphiteWithoutRepo(argv, canonical, async (context) => {
-    context.splog.page(
-      fs.readFileSync(path.join(__dirname, '..', 'lib', 'ch.fish'), {
-        encoding: 'utf-8',
-      })
-    );
+    context.splog.page(FISH_COMPLETION);
   });

--- a/apps/cli/src/commands/log.ts
+++ b/apps/cli/src/commands/log.ts
@@ -1,12 +1,12 @@
-import yargs from 'yargs';
+import { Argv } from 'yargs';
+import { registerCommands } from '../lib/register_commands';
+import * as logDefault from './log-commands/default';
+import * as logLong from './log-commands/long';
+import * as logShort from './log-commands/short';
 
 export const command = 'log <command>';
 export const desc = 'Commands that log your stacks.';
 export const aliases = ['l'];
-export const builder = function (yargs: yargs.Argv): yargs.Argv {
-  return yargs
-    .commandDir('log-commands', {
-      extensions: ['js'],
-    })
-    .strict();
+export const builder = function (yargs: Argv): Argv {
+  return registerCommands(yargs, [logDefault, logLong, logShort]).strict();
 };

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -1,14 +1,27 @@
 import { Argv } from 'yargs';
+import { registerCommands } from '../lib/register_commands';
+import * as repoDisableGithub from './repo-commands/repo_disable_github';
+import * as repoInit from './repo-commands/repo_init';
+import * as repoName from './repo-commands/repo_name';
+import * as repoOwner from './repo-commands/repo_owner';
+import * as repoPrTemplates from './repo-commands/repo_pr_templates';
+import * as repoRemote from './repo-commands/repo_remote';
+import * as repoSync from './repo-commands/repo_sync';
 
 export const command = 'repo <command>';
 export const desc =
   "Read or write Charcoal's configuration settings for the current repo. Run `ch repo --help` to learn more.";
 
 export const builder = function (yargs: Argv): Argv {
-  return yargs
-    .commandDir('repo-commands', {
-      extensions: ['js'],
-    })
+  return registerCommands(yargs, [
+    repoInit,
+    repoName,
+    repoOwner,
+    repoRemote,
+    repoPrTemplates,
+    repoSync,
+    repoDisableGithub,
+  ])
     .strict()
     .demandCommand();
 };

--- a/apps/cli/src/commands/user.ts
+++ b/apps/cli/src/commands/user.ts
@@ -1,14 +1,29 @@
 import { Argv } from 'yargs';
+import { registerCommands } from '../lib/register_commands';
+import * as branchDate from './user-commands/branch_date';
+import * as branchPrefix from './user-commands/branch_prefix';
+import * as branchReplacement from './user-commands/branch_replacement';
+import * as editor from './user-commands/editor';
+import * as pager from './user-commands/pager';
+import * as restackDate from './user-commands/restack_date';
+import * as submitBody from './user-commands/submit_body';
+import * as tips from './user-commands/tips';
 
 export const command = 'user <command>';
 export const desc =
   "Read or write Charcoal's user configuration settings. Run `ch user --help` to learn more.";
 
 export const builder = function (yargs: Argv): Argv {
-  return yargs
-    .commandDir('user-commands', {
-      extensions: ['js'],
-    })
+  return registerCommands(yargs, [
+    branchDate,
+    branchPrefix,
+    branchReplacement,
+    editor,
+    pager,
+    restackDate,
+    submitBody,
+    tips,
+  ])
     .strict()
     .demandCommand();
 };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,9 +3,48 @@
 
 import chalk from 'chalk';
 import tmp from 'tmp';
-import yargs from 'yargs';
+import yargs, { CommandModule } from 'yargs';
 import { globalArgumentsOptions } from './lib/global_arguments';
 import { getYargsInput } from './lib/pre-yargs/preprocess_command';
+import { registerCommands } from './lib/register_commands';
+import { registerCompletion } from './commands/completion';
+
+import * as auth from './commands/auth';
+import * as bottom from './commands/bottom';
+import * as checkout from './commands/checkout';
+import * as continueCmd from './commands/continue';
+import * as create from './commands/create';
+import * as deleteCmd from './commands/delete';
+import * as demo from './commands/demo';
+import * as dev from './commands/dev';
+import * as down from './commands/down';
+import * as edit from './commands/edit';
+import * as feedback from './commands/feedback';
+import * as fish from './commands/fish';
+import * as fold from './commands/fold';
+import * as get from './commands/get';
+import * as info from './commands/info';
+import * as init from './commands/init';
+import * as ll from './commands/ll';
+import * as log from './commands/log';
+import * as ls from './commands/ls';
+import * as modify from './commands/modify';
+import * as move from './commands/move';
+import * as pop from './commands/pop';
+import * as rename from './commands/rename';
+import * as reorder from './commands/reorder';
+import * as repo from './commands/repo';
+import * as restack from './commands/restack';
+import * as split from './commands/split';
+import * as squash from './commands/squash';
+import * as submit from './commands/submit';
+import * as sync from './commands/sync';
+import * as test from './commands/test';
+import * as top from './commands/top';
+import * as track from './commands/track';
+import * as untrack from './commands/untrack';
+import * as up from './commands/up';
+import * as user from './commands/user';
 
 // this line gets rid of warnings about "experimental fetch API" for our users
 // while still showing us warnings when we test with DEBUG=1
@@ -23,8 +62,52 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-void yargs(getYargsInput())
-  .commandDir('commands')
+// Registered explicitly (not via `.commandDir()`) so the command modules are
+// bundled into the single-file binary built with `bun build --compile`.
+const commandModules = [
+  auth,
+  bottom,
+  checkout,
+  continueCmd,
+  create,
+  deleteCmd,
+  demo,
+  dev,
+  down,
+  edit,
+  feedback,
+  fish,
+  fold,
+  get,
+  info,
+  init,
+  ll,
+  log,
+  ls,
+  modify,
+  move,
+  pop,
+  rename,
+  reorder,
+  repo,
+  restack,
+  split,
+  squash,
+  submit,
+  sync,
+  test,
+  top,
+  track,
+  untrack,
+  up,
+  user,
+] as unknown as CommandModule[];
+
+const cli = registerCompletion(
+  registerCommands(yargs(getYargsInput()), commandModules)
+);
+
+void cli
   .help()
   .usage(
     'Charcoal is a command line tool that makes working with stacked changes fast & intuitive.\n\nhttps://docs.graphite.dev/guides/graphite-cli'

--- a/apps/cli/src/lib/fish_completion.ts
+++ b/apps/cli/src/lib/fish_completion.ts
@@ -1,4 +1,5 @@
-### Installation: ch fish >> ~/.config/fish/completions/ch.fish
+// Inlined so it survives single-file binary compilation (no runtime file read).
+export const FISH_COMPLETION = String.raw`### Installation: ch fish >> ~/.config/fish/completions/ch.fish
 # git helpers adapted from fish git completion
 function __fish_git_local_branches
     command git for-each-ref --format='%(refname:strip=2)' refs/heads/ 2>/dev/null
@@ -29,3 +30,4 @@ complete -c ch -x -n "__fish_seen_subcommand_from checkout co delete dl track tr
 
 # ch get takes remote branches
 complete -c ch -x -n "__fish_seen_subcommand_from get g" -a "(__fish_git_remote_branches)"
+`;

--- a/apps/cli/src/lib/register_commands.ts
+++ b/apps/cli/src/lib/register_commands.ts
@@ -1,0 +1,15 @@
+import { Argv, CommandModule } from 'yargs';
+
+// Register command modules explicitly instead of yargs' `.commandDir()`, which
+// scans the filesystem at runtime and therefore breaks inside a single-file
+// (bun --compile) binary. Static `.command()` calls are bundler-visible.
+//
+// The modules are heterogeneous (each handler has its own args type), so they
+// can't share one `CommandModule<T, U>` instantiation — hence the loose input.
+export function registerCommands(
+  yargs: Argv,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  modules: readonly any[]
+): Argv {
+  return modules.reduce((acc, mod) => acc.command(mod as CommandModule), yargs);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,17 +63,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:7.18.2":
-  version: 7.18.2
-  resolution: "@babel/generator@npm:7.18.2"
-  dependencies:
-    "@babel/types": ^7.18.2
-    "@jridgewell/gen-mapping": ^0.3.0
-    jsesc: ^2.5.1
-  checksum: d0661e95532ddd97566d41fec26355a7b28d1cbc4df95fe80cc084c413342935911b48db20910708db39714844ddd614f61c2ec4cca3fb10181418bdcaa2e7a3
-  languageName: node
-  linkType: hard
-
 "@babel/generator@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/generator@npm:7.18.6"
@@ -168,24 +157,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.18.10, @babel/helper-string-parser@npm:^7.19.4":
-  version: 7.19.4
-  resolution: "@babel/helper-string-parser@npm:7.19.4"
-  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.19.1":
-  version: 7.19.1
-  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
-  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
@@ -215,15 +190,6 @@ __metadata:
     chalk: ^2.0.0
     js-tokens: ^4.0.0
   checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:7.18.4":
-  version: 7.18.4
-  resolution: "@babel/parser@npm:7.18.4"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: e05b2dc720c4b200e088258f3c2a2de5041c140444edc38181d1217b10074e881a7133162c5b62356061f26279f08df5a06ec14c5842996ee8601ad03c57a44f
   languageName: node
   linkType: hard
 
@@ -262,28 +228,6 @@ __metadata:
     debug: ^4.1.0
     globals: ^11.1.0
   checksum: 5427a9db63984b2600f62b257dab18e3fc057997b69d708573bfc88eb5eacd6678fb24fddba082d6ac050734b8846ce110960be841ea1e461d66e2cde72b6b07
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:7.19.0":
-  version: 7.19.0
-  resolution: "@babel/types@npm:7.19.0"
-  dependencies:
-    "@babel/helper-string-parser": ^7.18.10
-    "@babel/helper-validator-identifier": ^7.18.6
-    to-fast-properties: ^2.0.0
-  checksum: 9b346715a68aeede70ba9c685a144b0b26c53bcd595d448e24c8fa8df4d5956a5712e56ebadb7c85dcc32f218ee42788e37b93d50d3295c992072224cb3ef3fe
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.18.2":
-  version: 7.21.3
-  resolution: "@babel/types@npm:7.21.3"
-  dependencies:
-    "@babel/helper-string-parser": ^7.19.4
-    "@babel/helper-validator-identifier": ^7.19.1
-    to-fast-properties: ^2.0.0
-  checksum: b750274718ba9cefd0b81836c464009bb6ba339fccce51b9baff497a0a2d96c044c61dc90cf203cec0adc770454b53a9681c3f7716883c802b85ab84c365ba35
   languageName: node
   linkType: hard
 
@@ -340,7 +284,6 @@ __metadata:
     nock: ^13.2.6
     nyc: ^15.1.0
     pinst: ^3.0.0
-    pkg: ^5.8.1
     prettier: ^2.8.3
     prompts: ^2.4.2
     semver: ^7.3.7
@@ -1434,13 +1377,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"at-least-node@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "at-least-node@npm:1.0.0"
-  checksum: 463e2f8e43384f1afb54bc68485c436d7622acec08b6fad269b421cb1d29cebb5af751426793d0961ed243146fe4dc983402f6d5a51b720b277818dbf6f2e49e
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1448,28 +1384,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
-  version: 1.5.1
-  resolution: "base64-js@npm:1.5.1"
-  checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
-  languageName: node
-  linkType: hard
-
 "binary-extensions@npm:^2.0.0":
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
-  languageName: node
-  linkType: hard
-
-"bl@npm:^4.0.3":
-  version: 4.1.0
-  resolution: "bl@npm:4.1.0"
-  dependencies:
-    buffer: ^5.5.0
-    inherits: ^2.0.4
-    readable-stream: ^3.4.0
-  checksum: 9e8521fa7e83aa9427c6f8ccdcba6e8167ef30cc9a22df26effcc5ab682ef91d2cbc23a239f945d099289e4bbcfae7a192e9c28c84c6202e710a0dfec3722662
   languageName: node
   linkType: hard
 
@@ -1526,16 +1444,6 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^5.5.0":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.1.13
-  checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
   languageName: node
   linkType: hard
 
@@ -1743,13 +1651,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^1.1.1":
-  version: 1.1.4
-  resolution: "chownr@npm:1.1.4"
-  checksum: 115648f8eb38bac5e41c3857f3e663f9c39ed6480d1349977c4d96c95a47266fcacc5a5aabf3cb6c481e22d72f41992827db47301851766c4fd77ac21a4f081d
-  languageName: node
-  linkType: hard
-
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -1896,7 +1797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:^1.0.2, core-util-is@npm:~1.0.0":
+"core-util-is@npm:^1.0.2":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
@@ -1983,13 +1884,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deep-extend@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "deep-extend@npm:0.6.0"
-  checksum: 7be7e5a8d468d6b10e6a67c3de828f55001b6eb515d014f7aeb9066ce36bd5717161eb47d6a0f7bed8a9083935b465bc163ee2581c8b128d29bf61092fdf57a7
-  languageName: node
-  linkType: hard
-
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -2034,13 +1928,6 @@ __metadata:
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "detect-libc@npm:2.0.1"
-  checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
   languageName: node
   linkType: hard
 
@@ -2122,7 +2009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+"end-of-stream@npm:^1.1.0":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -2569,13 +2456,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expand-template@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "expand-template@npm:2.0.3"
-  checksum: 588c19847216421ed92befb521767b7018dc88f88b0576df98cb242f20961425e96a92cbece525ef28cc5becceae5d544ae0f5b9b5e2aa05acb13716ca5b3099
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -2753,27 +2633,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"from2@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "from2@npm:2.3.0"
-  dependencies:
-    inherits: ^2.0.1
-    readable-stream: ^2.0.0
-  checksum: 6080eba0793dce32f475141fb3d54cc15f84ee52e420ee22ac3ab0ad639dc95a1875bc6eb9c0e1140e94972a36a89dc5542491b85f1ab8df0c126241e0f1a61b
-  languageName: node
-  linkType: hard
-
 "fromentries@npm:^1.2.0":
   version: 1.3.2
   resolution: "fromentries@npm:1.3.2"
   checksum: 33729c529ce19f5494f846f0dd4945078f4e37f4e8955f4ae8cc7385c218f600e9d93a7d225d17636c20d1889106fd87061f911550861b7072f53bf891e6b341
-  languageName: node
-  linkType: hard
-
-"fs-constants@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs-constants@npm:1.0.0"
-  checksum: 18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
   languageName: node
   linkType: hard
 
@@ -2785,18 +2648,6 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "fs-extra@npm:9.1.0"
-  dependencies:
-    at-least-node: ^1.0.0
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: ba71ba32e0faa74ab931b7a0031d1523c66a73e225de7426e275e238e312d07313d2da2d33e34a52aa406c8763ade5712eb3ec9ba4d9edce652bcacdc29e6b20
   languageName: node
   linkType: hard
 
@@ -2948,13 +2799,6 @@ __metadata:
   dependencies:
     resolve-pkg-maps: ^1.0.0
   checksum: 172358903250eff0103943f816e8a4e51d29b8e5449058bdf7266714a908a48239f6884308bd3a6ff28b09f692b9533dbebfd183ab63e4e14f073cda91f1bca9
-  languageName: node
-  linkType: hard
-
-"github-from-package@npm:0.0.0":
-  version: 0.0.0
-  resolution: "github-from-package@npm:0.0.0"
-  checksum: 14e448192a35c1e42efee94c9d01a10f42fe790375891a24b25261246ce9336ab9df5d274585aedd4568f7922246c2a78b8a8cd2571bfe99c693a9718e7dd0e3
   languageName: node
   linkType: hard
 
@@ -3249,13 +3093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
-  version: 1.2.1
-  resolution: "ieee754@npm:1.2.1"
-  checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.1.4":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
@@ -3311,17 +3148,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:^2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
-  languageName: node
-  linkType: hard
-
-"ini@npm:~1.3.0":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
   languageName: node
   linkType: hard
 
@@ -3333,16 +3163,6 @@ __metadata:
     has: ^1.0.3
     side-channel: ^1.0.4
   checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
-  languageName: node
-  linkType: hard
-
-"into-stream@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "into-stream@npm:6.0.0"
-  dependencies:
-    from2: ^2.3.0
-    p-is-promise: ^3.0.0
-  checksum: 8df24c9eadd7cdd1cbc160bc20914b961dfd0ca29767785b69e698f799e85466b6f7c637d237dca1472d09d333399f70cc05a2fb8d08cb449dc9a80d92193980
   languageName: node
   linkType: hard
 
@@ -3388,21 +3208,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:2.9.0, is-core-module@npm:^2.8.1, is-core-module@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "is-core-module@npm:2.9.0"
-  dependencies:
-    has: ^1.0.3
-  checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
-  languageName: node
-  linkType: hard
-
 "is-core-module@npm:^2.11.0":
   version: 2.13.0
   resolution: "is-core-module@npm:2.13.0"
   dependencies:
     has: ^1.0.3
   checksum: 053ab101fb390bfeb2333360fd131387bed54e476b26860dc7f5a700bbf34a0ec4454f7c8c4d43e8a0030957e4b3db6e16d35e1890ea6fb654c833095e040355
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.8.1, is-core-module@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "is-core-module@npm:2.9.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
   languageName: node
   linkType: hard
 
@@ -3553,13 +3373,6 @@ __metadata:
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
   checksum: 438b7e52656fe3b9b293b180defb4e448088e7023a523ec21a91a80b9ff8cdb3377ddb5b6e60f7c7de4fa8b63ab56e121b6705fe081b3cf1b828b0a380009ad7
-  languageName: node
-  linkType: hard
-
-"isarray@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "isarray@npm:1.0.0"
-  checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
@@ -3997,13 +3810,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.3":
-  version: 1.2.8
-  resolution: "minimist@npm:1.2.8"
-  checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
-  languageName: node
-  linkType: hard
-
 "minipass-collect@npm:^1.0.2":
   version: 1.0.2
   resolution: "minipass-collect@npm:1.0.2"
@@ -4078,13 +3884,6 @@ __metadata:
     minipass: ^3.0.0
     yallist: ^4.0.0
   checksum: f1fdeac0b07cf8f30fcf12f4b586795b97be856edea22b5e9072707be51fc95d41487faec3f265b42973a304fe3a64acd91a44a3826a963e37b37bafde0212c3
-  languageName: node
-  linkType: hard
-
-"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "mkdirp-classic@npm:0.5.3"
-  checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
   languageName: node
   linkType: hard
 
@@ -4182,29 +3981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multistream@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "multistream@npm:4.1.0"
-  dependencies:
-    once: ^1.4.0
-    readable-stream: ^3.6.0
-  checksum: 305c49a1aadcb7f63f64d8ca2bb6e7852e5f7dba94c7329e9a72ce53cd0046686b71668dc1adbf123f17d2dd107765fc946e64c36a26b15c470a3146ea3bc923
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:3.3.3":
   version: 3.3.3
   resolution: "nanoid@npm:3.3.3"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: ada019402a07464a694553c61d2dca8a4353645a7d92f2830f0d487fedff403678a0bee5323a46522752b2eab95a0bc3da98b6cccaa7c0c55cd9975130e6d6f0
-  languageName: node
-  linkType: hard
-
-"napi-build-utils@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "napi-build-utils@npm:1.0.2"
-  checksum: 06c14271ee966e108d55ae109f340976a9556c8603e888037145d6522726aebe89dd0c861b4b83947feaf6d39e79e08817559e8693deedc2c94e82c5cbd090c7
   languageName: node
   linkType: hard
 
@@ -4241,15 +4023,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abi@npm:^3.3.0":
-  version: 3.33.0
-  resolution: "node-abi@npm:3.33.0"
-  dependencies:
-    semver: ^7.3.5
-  checksum: 59e5e00d9a15225087b6dd55b7d4f99686a6d64a8bdbe2c9aa98f4f74554873a7225d3dc975fa32718e7695eed8abcfeaae58b03db118a01392f6d25b0469b52
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:^2.6.1":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -4261,20 +4034,6 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.6":
-  version: 2.6.9
-  resolution: "node-fetch@npm:2.6.9"
-  dependencies:
-    whatwg-url: ^5.0.0
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
   languageName: node
   linkType: hard
 
@@ -4473,13 +4232,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-is-promise@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "p-is-promise@npm:3.0.0"
-  checksum: 74e511225fde5eeda7a120d51c60c284de90d68dec7c73611e7e59e8d1c44cc7e2246686544515849149b74ed0571ad470a456ac0d00314f8d03d2cc1ad43aae
-  languageName: node
-  linkType: hard
-
 "p-limit@npm:^1.1.0":
   version: 1.3.0
   resolution: "p-limit@npm:1.3.0"
@@ -4675,75 +4427,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg-fetch@npm:3.4.2":
-  version: 3.4.2
-  resolution: "pkg-fetch@npm:3.4.2"
-  dependencies:
-    chalk: ^4.1.2
-    fs-extra: ^9.1.0
-    https-proxy-agent: ^5.0.0
-    node-fetch: ^2.6.6
-    progress: ^2.0.3
-    semver: ^7.3.5
-    tar-fs: ^2.1.1
-    yargs: ^16.2.0
-  bin:
-    pkg-fetch: lib-es5/bin.js
-  checksum: e0f73cedf6cb8882e4d998700031443e6542d213f9817d66deb03fb89c122ca7f7505f11401f85a760a2d3951f9b793d0f78782be220c46c56ccf70f9915812a
-  languageName: node
-  linkType: hard
-
-"pkg@npm:^5.8.1":
-  version: 5.8.1
-  resolution: "pkg@npm:5.8.1"
-  dependencies:
-    "@babel/generator": 7.18.2
-    "@babel/parser": 7.18.4
-    "@babel/types": 7.19.0
-    chalk: ^4.1.2
-    fs-extra: ^9.1.0
-    globby: ^11.1.0
-    into-stream: ^6.0.0
-    is-core-module: 2.9.0
-    minimist: ^1.2.6
-    multistream: ^4.1.0
-    pkg-fetch: 3.4.2
-    prebuild-install: 7.1.1
-    resolve: ^1.22.0
-    stream-meter: ^1.0.4
-  peerDependencies:
-    node-notifier: ">=9.0.1"
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    pkg: lib-es5/bin.js
-  checksum: 5e750e716c3426706ea1fbd26832faf6a3ab8376b99f20aeb9c40fd48ad48e7b51375cd077b77669f3bfbefee69cc8111f49e0ca39e353fd0fc2dff95a57f822
-  languageName: node
-  linkType: hard
-
-"prebuild-install@npm:7.1.1":
-  version: 7.1.1
-  resolution: "prebuild-install@npm:7.1.1"
-  dependencies:
-    detect-libc: ^2.0.0
-    expand-template: ^2.0.3
-    github-from-package: 0.0.0
-    minimist: ^1.2.3
-    mkdirp-classic: ^0.5.3
-    napi-build-utils: ^1.0.1
-    node-abi: ^3.3.0
-    pump: ^3.0.0
-    rc: ^1.2.7
-    simple-get: ^4.0.0
-    tar-fs: ^2.0.0
-    tunnel-agent: ^0.6.0
-  bin:
-    prebuild-install: bin.js
-  checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
-  languageName: node
-  linkType: hard
-
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -4796,26 +4479,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-nextick-args@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "process-nextick-args@npm:2.0.1"
-  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
-  languageName: node
-  linkType: hard
-
 "process-on-spawn@npm:^1.0.0":
   version: 1.0.0
   resolution: "process-on-spawn@npm:1.0.0"
   dependencies:
     fromentries: ^1.2.0
   checksum: 597769e3db6a8e2cb1cd64a952bbc150220588debac31c7cf1a9f620ce981e25583d8d70848d8a14953577608512984a8808c3be77e09af8ebdcdc14ec23a295
-  languageName: node
-  linkType: hard
-
-"progress@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "progress@npm:2.0.3"
-  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
   languageName: node
   linkType: hard
 
@@ -4890,46 +4559,6 @@ __metadata:
   dependencies:
     safe-buffer: ^5.1.0
   checksum: d779499376bd4cbb435ef3ab9a957006c8682f343f14089ed5f27764e4645114196e75b7f6abf1cbd84fd247c0cb0651698444df8c9bf30e62120fbbc52269d6
-  languageName: node
-  linkType: hard
-
-"rc@npm:^1.2.7":
-  version: 1.2.8
-  resolution: "rc@npm:1.2.8"
-  dependencies:
-    deep-extend: ^0.6.0
-    ini: ~1.3.0
-    minimist: ^1.2.0
-    strip-json-comments: ~2.0.1
-  bin:
-    rc: ./cli.js
-  checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^2.0.0, readable-stream@npm:^2.1.4":
-  version: 2.3.8
-  resolution: "readable-stream@npm:2.3.8"
-  dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~2.0.0
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.1.1
-    util-deprecate: ~1.0.1
-  checksum: 65645467038704f0c8aaf026a72fbb588a9e2ef7a75cd57a01702ee9db1c4a1e4b03aaad36861a6a0926546a74d174149c8c207527963e0c2d3eee2f37678a42
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: bdcbe6c22e846b6af075e32cf8f4751c2576238c5043169a1c221c92ee2878458a816a4ea33f4c67623c0b6827c8a400409bfb3cf0bf3381392d0b1dfb52ac8d
   languageName: node
   linkType: hard
 
@@ -5098,17 +4727,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
-  languageName: node
-  linkType: hard
-
-"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
+  languageName: node
+  linkType: hard
+
+"safe-buffer@npm:~5.2.0":
+  version: 5.2.1
+  resolution: "safe-buffer@npm:5.2.1"
+  checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
   languageName: node
   linkType: hard
 
@@ -5197,24 +4826,6 @@ __metadata:
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
-  languageName: node
-  linkType: hard
-
-"simple-concat@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "simple-concat@npm:1.0.1"
-  checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
-  languageName: node
-  linkType: hard
-
-"simple-get@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "simple-get@npm:4.0.1"
-  dependencies:
-    decompress-response: ^6.0.0
-    once: ^1.3.1
-    simple-concat: ^1.0.0
-  checksum: e4132fd27cf7af230d853fa45c1b8ce900cb430dd0a3c6d3829649fe4f2b26574c803698076c4006450efb0fad2ba8c5455fbb5755d4b0a5ec42d4f12b31d27e
   languageName: node
   linkType: hard
 
@@ -5307,15 +4918,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-meter@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "stream-meter@npm:1.0.4"
-  dependencies:
-    readable-stream: ^2.1.4
-  checksum: a732f7ede9dadd6214083aaf4e3014d664498a56b91cdbc4e6abae59ec8ae507883f58f1f3ca7a939cdb9cc8e2320997241191e9fb8c7717f3fad9ca8cb5dc46
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -5358,15 +4960,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:~1.1.1":
-  version: 1.1.1
-  resolution: "string_decoder@npm:1.1.1"
-  dependencies:
-    safe-buffer: ~5.1.0
-  checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
-  languageName: node
-  linkType: hard
-
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -5401,13 +4994,6 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "strip-json-comments@npm:2.0.1"
-  checksum: 1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
   languageName: node
   linkType: hard
 
@@ -5449,31 +5035,6 @@ __metadata:
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
-  languageName: node
-  linkType: hard
-
-"tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "tar-fs@npm:2.1.1"
-  dependencies:
-    chownr: ^1.1.1
-    mkdirp-classic: ^0.5.2
-    pump: ^3.0.0
-    tar-stream: ^2.1.4
-  checksum: f5b9a70059f5b2969e65f037b4e4da2daf0fa762d3d232ffd96e819e3f94665dbbbe62f76f084f1acb4dbdcce16c6e4dac08d12ffc6d24b8d76720f4d9cf032d
-  languageName: node
-  linkType: hard
-
-"tar-stream@npm:^2.1.4":
-  version: 2.2.0
-  resolution: "tar-stream@npm:2.2.0"
-  dependencies:
-    bl: ^4.0.3
-    end-of-stream: ^1.4.1
-    fs-constants: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^3.1.1
-  checksum: 699831a8b97666ef50021c767f84924cfee21c142c2eb0e79c63254e140e6408d6d55a065a2992548e72b06de39237ef2b802b99e3ece93ca3904a37622a66f3
   languageName: node
   linkType: hard
 
@@ -5676,15 +5237,6 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
-  languageName: node
-  linkType: hard
-
-"tunnel-agent@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "tunnel-agent@npm:0.6.0"
-  dependencies:
-    safe-buffer: ^5.0.1
-  checksum: 05f6510358f8afc62a057b8b692f05d70c1782b70db86d6a1e0d5e28a32389e52fa6e7707b6c5ecccacc031462e4bc35af85ecfe4bbc341767917b7cf6965711
   languageName: node
   linkType: hard
 
@@ -5912,7 +5464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
+"util-deprecate@npm:^1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
@@ -6125,7 +5677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:16.2.0, yargs@npm:^16.2.0":
+"yargs@npm:16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
## What

Replaces `pkg` (archived/deprecated) with **Bun** (`bun build --compile`) for building the standalone release binaries.

## Why

`pkg` is unmaintained and is what pins the binary to node 18 (#107). Bun is actively maintained, and it **cross-compiles every target from a single Linux runner** — so CI drops the macOS runners entirely.

## How

A single-file Bun binary has no scannable filesystem, so two app changes were required (a Bun binary of the old code crashed with `scandir '/$bunfs/root/commands'`):

- **Static command registration** — replaced every `yargs.commandDir()` (runtime `readdirSync`, bundler-invisible) with explicit `.command()` calls via a small `registerCommands` helper. Covers `index.ts` and the `repo`/`user`/`log`/`dev`/`feedback` groups. `completion` is now registered via an exported `registerCompletion()`.
- **Inlined the fish completion** — `ch.fish` became a `FISH_COMPLETION` string constant (`src/lib/fish_completion.ts`); `ch fish` no longer reads a file at `__dirname`.

Build/CI:
- `build-pkg` → `build-binary` (`bun build --compile`); removed the `pkg` config + devDependency and the `cp ch.fish` build step.
- Release workflow: one ubuntu runner cross-compiles `ch-macos-arm64`, `ch-macos-x64`, `ch-linux`.
- Added a Bun compile + smoke check to PR CI (the release build only runs on push/tags, so PRs wouldn't otherwise catch a broken binary).

## Testing

- Full node test suite green (static registration changes nothing for `node`/tests).
- Compiled the native Bun binary and ran a **real workflow** in a scratch repo: `init` (writes config), `create` (branch + metadata), `ls`, `up`/`down` — all correct. Verified every command shape (flat, aliases, `repo`/`log` groups + subcommands), `fish`, `completion`, and `--get-yargs-completions`.
- All three targets cross-compile (arm64/x64 Mach-O + x86-64 ELF).
- Binaries are larger (~60–90 MB; they bundle the Bun runtime) — expected.

## Notes

- Closes the `pkg` half of #107. The dev/test node-22 upgrade can follow separately (the binary no longer depends on a bundled node).
- The hidden `demo` command (already non-functional in the fork — it force-pushes to `withgraphite/graphite-demo-repo`) isn't supported in the compiled binary; works fine via `npm`/node.
- The Homebrew formula is unchanged (artifact names are still `ch-macos-arm64`/`ch-macos-x64`/`ch-linux`).

Top of the 1.0.0 stack — **tag `v1.0.0` only after this merges** so 1.0.0 ships Bun binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
