### PR TITLE
Harden the gh-CLI-as-API layer (fork repo, fail-loud, concurrency, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Graphite is an amazing company and you should absolutely check out their product
 
 However, many organizations aren't interested in paying for Graphite's team plan at this time.
 
-The Graphite CLI does not need to depend on Graphite's API, so this project allows for use of the CLI with any git repository (even ones hosted on platforms other than GitHub!), entirely for free.
+The Graphite CLI does not need to depend on Graphite's API, so this project lets you use it with your own GitHub repositories, entirely for free.
+
+> [!NOTE]
+> Charcoal talks to GitHub through the [GitHub CLI (`gh`)](https://cli.github.com) rather than Graphite's API, so PR features (`submit`, `get`, PR-aware `sync`) require `gh` to be installed and authenticated (`ch auth`) and work with **GitHub** repositories. Local stacking commands work with any git repo. (Earlier versions aspired to support GitLab/Bitbucket; that isn't implemented.)
 
 ## Commands
 

--- a/apps/cli/src/actions/submit/prepare_branches.ts
+++ b/apps/cli/src/actions/submit/prepare_branches.ts
@@ -7,7 +7,10 @@ import { getPRTitle } from './pr_title';
 import { getReviewers } from './reviewers';
 import { TPRSubmissionInfo } from './submit_prs';
 import { PreconditionsFailedError } from '../../lib/errors';
-import { getGithubAuthorizationStatus } from '../../commands/auth';
+import {
+  getGithubAuthorizationStatus,
+  isGhInstalled,
+} from '../../commands/auth';
 
 type TPRSubmissionAction = { branchName: string } & (
   | { update: false }
@@ -328,10 +331,16 @@ async function getReviewersMaybeInteractively(
 }
 
 function cliAuthPrecondition(context: TContext): boolean {
-  const isGhAuthorized = getGithubAuthorizationStatus();
-
   const isGithubIntegrationEnabled =
     context.repoConfig.getIsGithubIntegrationEnabled();
+
+  if (isGithubIntegrationEnabled && !isGhInstalled()) {
+    throw new PreconditionsFailedError(
+      `The GitHub CLI (\`gh\`) is required but was not found on your PATH. Install it from https://cli.github.com and run \`ch auth\`. To use Charcoal without GitHub integration, run \`ch repo github --no-enable\`.`
+    );
+  }
+
+  const isGhAuthorized = getGithubAuthorizationStatus();
 
   if (isGithubIntegrationEnabled && !isGhAuthorized) {
     throw new PreconditionsFailedError(

--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { githubRepoSlug } from '../../lib/api/github_repo';
 import { TContext } from '../../lib/context';
 import { TScopeSpec } from '../../lib/engine/scope_spec';
 import { ExitFailedError, KilledError } from '../../lib/errors';
@@ -142,6 +143,7 @@ export async function submitAction(
 
   // Submitting changes the dependency tree of the submitted branches *and*
   // their ancestors, so refresh footers for both (#85).
+  const repo = githubRepoSlug(context);
   const branchesToUpdate = new Set<string>(branchNames);
   for (const branch of branchNames) {
     let ancestor = context.engine.getParent(branch);
@@ -168,6 +170,8 @@ export async function submitAction(
         'pr',
         'edit',
         `${prInfo.number}`,
+        '--repo',
+        repo,
         '--body',
         updatePrBodyFooter(prInfo.body, footer),
       ]);

--- a/apps/cli/src/actions/submit/submit_prs.ts
+++ b/apps/cli/src/actions/submit/submit_prs.ts
@@ -1,6 +1,7 @@
 import { API_ROUTES } from '@withgraphite/graphite-cli-routes';
 import * as t from '@withgraphite/retype';
 import chalk from 'chalk';
+import { githubRepoSlug } from '../../lib/api/github_repo';
 import { TContext } from '../../lib/context';
 import { ExitFailedError } from '../../lib/errors';
 import { Unpacked } from '../../lib/utils/ts_helpers';
@@ -27,6 +28,7 @@ export async function submitPullRequest(
 ): Promise<void> {
   const pr = await requestServerToSubmitPR({
     submissionInfo,
+    repo: githubRepoSlug(context),
   });
 
   if (pr.response.status === 'error') {
@@ -59,14 +61,17 @@ export async function submitPullRequest(
 
 async function requestServerToSubmitPR({
   submissionInfo,
+  repo,
 }: {
   submissionInfo: TPRSubmissionInfo;
+  repo: string;
 }): Promise<TSubmittedPR> {
   const request = submissionInfo[0];
 
   try {
     const response = await submitPrToGithub({
       request,
+      repo,
     });
 
     return {
@@ -87,8 +92,10 @@ async function requestServerToSubmitPR({
 
 async function submitPrToGithub({
   request,
+  repo,
 }: {
   request: TSubmittedPRRequest;
+  repo: string;
 }): Promise<TSubmittedPRResponse> {
   // prepare_branches always attaches reviewers, but the route type only
   // declares them on the 'create' variant.
@@ -99,6 +106,8 @@ async function submitPrToGithub({
         'pr',
         'view',
         request.head,
+        '--repo',
+        repo,
         '--json',
         'headRefName,url,number,baseRefName,body',
       ]).toString()
@@ -118,7 +127,14 @@ async function submitPrToGithub({
     ];
 
     if (editArgs.length) {
-      execFileSync('gh', ['pr', 'edit', prInfo.headRefName, ...editArgs]);
+      execFileSync('gh', [
+        'pr',
+        'edit',
+        prInfo.headRefName,
+        '--repo',
+        repo,
+        ...editArgs,
+      ]);
     }
 
     return {
@@ -135,6 +151,8 @@ async function submitPrToGithub({
       const result = execFileSync('gh', [
         'pr',
         'create',
+        '--repo',
+        repo,
         '--head',
         request.head,
         '--base',

--- a/apps/cli/src/actions/sync/get.ts
+++ b/apps/cli/src/actions/sync/get.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { execFileSync } from 'child_process';
+import { githubRepoSlug } from '../../lib/api/github_repo';
 import { TContext } from '../../lib/context';
 import {
   ExitFailedError,
@@ -15,6 +16,7 @@ export async function getAction(
   context: TContext
 ): Promise<void> {
   const trunk = context.engine.trunk;
+  const repo = githubRepoSlug(context);
 
   let target = args.branchName ?? context.engine.currentBranch;
   if (!target) {
@@ -25,7 +27,7 @@ export async function getAction(
 
   // A numeric argument is a PR number; resolve it to its head branch.
   if (/^\d+$/.test(target)) {
-    target = prFieldOrThrow(target, 'headRefName');
+    target = prFieldOrThrow(target, 'headRefName', repo);
   }
 
   if (target === trunk) {
@@ -48,7 +50,7 @@ export async function getAction(
     }
     seen.add(branch);
     downstack.unshift(branch);
-    branch = prFieldMaybe(branch, 'baseRefName');
+    branch = prFieldMaybe(branch, 'baseRefName', repo);
   }
 
   if (branch !== trunk) {
@@ -74,13 +76,18 @@ export async function getAction(
 
 function prFieldMaybe(
   branchOrNumber: string,
-  field: 'headRefName' | 'baseRefName'
+  field: 'headRefName' | 'baseRefName',
+  repo: string
 ): string | undefined {
   try {
     const pr = JSON.parse(
-      execFileSync('gh', ['pr', 'view', branchOrNumber, '--json', field], {
-        stdio: ['ignore', 'pipe', 'ignore'],
-      }).toString()
+      execFileSync(
+        'gh',
+        ['pr', 'view', branchOrNumber, '--repo', repo, '--json', field],
+        {
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }
+      ).toString()
     );
     return pr[field] || undefined;
   } catch {
@@ -90,9 +97,10 @@ function prFieldMaybe(
 
 function prFieldOrThrow(
   branchOrNumber: string,
-  field: 'headRefName' | 'baseRefName'
+  field: 'headRefName' | 'baseRefName',
+  repo: string
 ): string {
-  const value = prFieldMaybe(branchOrNumber, field);
+  const value = prFieldMaybe(branchOrNumber, field, repo);
   if (!value) {
     throw new ExitFailedError(
       `Could not find an open pull request for "${branchOrNumber}".`

--- a/apps/cli/src/actions/sync_pr_info.ts
+++ b/apps/cli/src/actions/sync_pr_info.ts
@@ -1,4 +1,5 @@
 import { getPrInfoForBranches, TPRInfoToUpsert } from '../lib/api/pr_info';
+import { githubRepoSlug } from '../lib/api/github_repo';
 import { TContext } from '../lib/context';
 import { TEngine } from '../lib/engine/engine';
 
@@ -16,7 +17,8 @@ export async function syncPrInfo(
     branchNames.map((branchName) => ({
       branchName,
       prNumber: context.engine.getPrInfo(branchName)?.number,
-    }))
+    })),
+    githubRepoSlug(context)
   );
 
   upsertPrInfoForBranches(upsertInfo, context.engine);

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -58,7 +58,7 @@ export const handler = async (argv: argsT): Promise<void> => {
   });
 };
 
-const getGhVersion = (): string | null => {
+export const getGhVersion = (): string | null => {
   try {
     const output = execFileSync('gh', ['--version']).toString();
     const match = output.match(/gh version (\d+\.\d+\.\d+)/);
@@ -67,6 +67,8 @@ const getGhVersion = (): string | null => {
     return null;
   }
 };
+
+export const isGhInstalled = (): boolean => getGhVersion() !== null;
 
 export const getGithubAuthorizationStatus = (): boolean => {
   try {

--- a/apps/cli/src/lib/api/github_repo.ts
+++ b/apps/cli/src/lib/api/github_repo.ts
@@ -1,0 +1,8 @@
+import { TContext } from '../context';
+
+// The `owner/name` slug to scope every `gh` call with `--repo`. Without it, gh
+// resolves the target repo from the cwd's remotes — which picks the *parent*
+// for a fork, so submit/get would operate on the wrong repository.
+export function githubRepoSlug(context: TContext): string {
+  return `${context.repoConfig.getRepoOwner()}/${context.repoConfig.getRepoName()}`;
+}

--- a/apps/cli/src/lib/api/pr_info.ts
+++ b/apps/cli/src/lib/api/pr_info.ts
@@ -1,7 +1,11 @@
 import { API_ROUTES } from '@withgraphite/graphite-cli-routes';
 
 import t from '@withgraphite/retype';
-import { execFileSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { ExitFailedError } from '../errors';
+
+const execFileAsync = promisify(execFile);
 
 type TBranchNameWithPrNumber = {
   branchName: string;
@@ -13,7 +17,8 @@ export type TPRInfoToUpsert = t.UnwrapSchemaMap<
 >['prs'];
 
 export async function getPrInfoForBranches(
-  branchNamesWithExistingPrInfo: TBranchNameWithPrNumber[]
+  branchNamesWithExistingPrInfo: TBranchNameWithPrNumber[],
+  repo: string
 ): Promise<TPRInfoToUpsert> {
   // We sync branches without existing PR info by name.  For branches
   // that are already associated with a PR, we only sync if both the
@@ -30,21 +35,22 @@ export async function getPrInfoForBranches(
     }
   });
 
-  try {
-    const response: TPRInfoToUpsert = [];
-
-    // Gh CLI allows for looking up by pr number of branch name
-    for (const prId of [...existingPrInfo.keys(), ...branchesWithoutPrInfo]) {
+  // gh can look up by PR number or branch name. These lookups are independent,
+  // so run them concurrently rather than one blocking subprocess at a time.
+  const prIds = [...existingPrInfo.keys(), ...branchesWithoutPrInfo];
+  const results = await Promise.all(
+    prIds.map(async (prId) => {
       try {
-        const pr = await JSON.parse(
-          execFileSync('gh', [
-            'pr',
-            'view',
-            `${prId}`,
-            '--json',
-            'state,url,title,body,number,headRefName,baseRefName,reviewDecision,isDraft',
-          ]).toString()
-        );
+        const { stdout } = await execFileAsync('gh', [
+          'pr',
+          'view',
+          `${prId}`,
+          '--repo',
+          repo,
+          '--json',
+          'state,url,title,body,number,headRefName,baseRefName,reviewDecision,isDraft',
+        ]);
+        const pr = JSON.parse(stdout);
 
         pr.prNumber = pr.number;
         delete pr.number;
@@ -53,35 +59,46 @@ export async function getPrInfoForBranches(
           pr.reviewDecision = undefined;
         }
 
-        response.push(pr);
+        return pr;
       } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes('no pull requests found')
-        ) {
-          continue;
+        const detail =
+          error instanceof Error
+            ? `${error.message}\n${
+                (error as Error & { stderr?: string }).stderr ?? ''
+              }`
+            : String(error);
+
+        // A branch simply having no PR is expected; anything else (gh missing,
+        // auth expired, rate limit, network) is a real failure we must surface
+        // rather than silently treating it as "no PR info".
+        if (/no .*pull requests found/i.test(detail)) {
+          return undefined;
         }
 
-        throw error;
+        throw new ExitFailedError(
+          [
+            `Failed to fetch pull request info from GitHub (via \`gh\`) for "${prId}".`,
+            `Ensure the GitHub CLI is installed and authenticated (run \`ch auth\`).`,
+            detail.trim(),
+          ].join('\n')
+        );
       }
-    }
+    })
+  );
 
-    return response.filter((pr) => {
-      const branchNameIfAssociated = existingPrInfo.get(pr.prNumber);
+  const response: TPRInfoToUpsert = results.filter((pr) => pr !== undefined);
 
-      const shouldAssociatePrWithBranch =
-        !branchNameIfAssociated &&
-        pr.state === 'OPEN' &&
-        branchesWithoutPrInfo.has(pr.headRefName);
+  return response.filter((pr) => {
+    const branchNameIfAssociated = existingPrInfo.get(pr.prNumber);
 
-      const shouldUpdateExistingBranch =
-        branchNameIfAssociated === pr.headRefName;
+    const shouldAssociatePrWithBranch =
+      !branchNameIfAssociated &&
+      pr.state === 'OPEN' &&
+      branchesWithoutPrInfo.has(pr.headRefName);
 
-      return shouldAssociatePrWithBranch || shouldUpdateExistingBranch;
-    });
-  } catch {
-    // Not really sure why this pattern was accepted but when this used the
-    // Graphite API they'd just return an empty array if the request failed.
-    return [];
-  }
+    const shouldUpdateExistingBranch =
+      branchNameIfAssociated === pr.headRefName;
+
+    return shouldAssociatePrWithBranch || shouldUpdateExistingBranch;
+  });
 }


### PR DESCRIPTION
## What

Hardens the `gh`-CLI-as-API layer (the limitations surfaced in the v1.0.0 bug-bash review).

## Fixes

**1. Scope every `gh` call to the configured repo (`--repo <owner>/<name>`).**
Previously no `gh` call passed `--repo`, so gh resolved the target from the cwd's remotes — which picks the **parent** for a fork. In a fork clone, `ch submit`/`get`/`sync` would read & create PRs against the **wrong repository**. Now all `gh pr view|create|edit` calls are scoped via a `githubRepoSlug(context)` helper. *(Verified: in a fork clone whose gh default was `searleser97/graphite-cli`, every PR call now targets `danerwilliams/charcoal`.)*

**2. Fail loud on `gh` failures instead of silently returning `[]`.**
`getPrInfoForBranches` had a catch-all `return []` (its own comment: *"Not really sure why this pattern was accepted…"*) — a gh error (rate limit, network, auth) silently became "no PRs," leaving a stale cache. It now throws a clear error (`… run \`ch auth\``) on real failures, while still treating "no pull requests found" as expected. Also: `cliAuthPrecondition` now distinguishes **gh-not-installed** ("install from cli.github.com") from **not-authed** ("run `ch auth`").

**3. Fetch PR info concurrently.**
`getPrInfoForBranches` did one `gh pr view` per branch sequentially; it now runs them with `Promise.all` (async `execFile`). Submit/footer **writes** stay ordered (a child's base must exist first).

**5. Docs.**
README no longer claims support for non-GitHub platforms — collaboration goes through `gh`→GitHub; only local stacking is platform-agnostic.

## Testing

- Full node suite green (no regressions).
- Live E2E against the real repo with the Bun binary:
  - **#1**: fork clone (upstream remote, no `set-default`) → all `gh pr` calls carry `--repo danerwilliams/charcoal`; none hit the parent.
  - **#2**: `gh pr view` forced to fail → `ch sync` errors loudly (was silent); a mixed stack (PR'd + unsubmitted branch) still skips the no-PR branch without throwing.
  - **#3**: `ch sync` refreshes PR info for the submitted branch concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
