### PR TITLE
v1.0.1: show `ch` in --help (not the runtime name)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danerwilliams/charcoal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "None",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -109,6 +109,10 @@ const cli = registerCompletion(
 );
 
 void cli
+  // Pin the program name; yargs otherwise derives it from the process, which is
+  // the runtime ("bun") in the compiled single-file binary, or "index.js" under
+  // node.
+  .scriptName('ch')
   .help()
   // Pin to the bundled version; yargs' default resolves package.json relative
   // to the cwd, which is wrong in the single-file binary / outside apps/cli.


### PR DESCRIPTION
## What

`v1.0.1` — fix the program name shown in `ch --help`.

## Why

`ch --help` rendered every command as `bun <command>` (e.g. `bun create`). yargs derives the program name (`$0`) from the running process; it was never pinned, so it showed `index.js` under node and the runtime name (`bun`) in the compiled single-file binary.

## Fix

- `index.ts`: `.scriptName('ch')` — help now always shows `ch <command>` regardless of how it's launched.
- Bump to `1.0.1`.

## Testing

- Verified `--help` shows `ch …` under both `node` and a freshly compiled Bun binary.
- Full node suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
