### PR TITLE
Preserve merged ancestors in PR stack footer (#139)

### DIFF
--- a/apps/cli/src/actions/create_pr_body_footer.ts
+++ b/apps/cli/src/actions/create_pr_body_footer.ts
@@ -1,4 +1,5 @@
 import { TContext } from '../lib/context';
+import { SCOPE } from '../lib/engine/scope_spec';
 
 export const footerTitle = '\n\n\n#### PR Dependency Tree\n\n';
 export const footerFooter =
@@ -15,7 +16,42 @@ export function createPrBodyFooter(context: TContext, branch: string): string {
     isForkHead: false,
   });
 
-  return `${footerTitle}${tree}${footerFooter}`;
+  return `${footerTitle}${buildMergedAncestors(
+    context,
+    branch
+  )}${tree}${footerFooter}`;
+}
+
+/**
+ * Renders PR references for ancestors that merged and were removed from the
+ * stack. Numbers are unioned across every branch in the live stack — not just
+ * the bottom — so the history survives reordering, wherever it is stored.
+ */
+function buildMergedAncestors(context: TContext, prBranch: string): string {
+  const liveStack = context.engine
+    .getRelativeStack(prBranch, SCOPE.STACK)
+    .filter((branch) => !context.engine.isTrunk(branch));
+
+  const liveNumbers = new Set(
+    liveStack
+      .map((branch) => context.engine.getPrInfo(branch)?.number)
+      .filter((number): number is number => number !== undefined)
+  );
+
+  const mergedNumbers = new Set<number>();
+  for (const branch of liveStack) {
+    for (const number of context.engine.getPrInfo(branch)
+      ?.mergedStackAncestors ?? []) {
+      if (!liveNumbers.has(number)) {
+        mergedNumbers.add(number);
+      }
+    }
+  }
+
+  return [...mergedNumbers]
+    .sort((a, b) => a - b)
+    .map((number) => `\n* ~~**PR #${number}**~~ (merged)`)
+    .join('');
 }
 
 /**

--- a/apps/cli/src/actions/create_pr_body_footer.ts
+++ b/apps/cli/src/actions/create_pr_body_footer.ts
@@ -9,65 +9,62 @@ export function createPrBodyFooter(context: TContext, branch: string): string {
 
   const tree = buildBranchTree({
     context,
-    currentBranches: [terminalParent],
+    branch: terminalParent,
     prBranch: branch,
-    currentDepth: 0,
+    depth: 0,
+    isForkHead: false,
   });
 
   return `${footerTitle}${tree}${footerFooter}`;
 }
 
+/**
+ * Renders the stack as a markdown list. A stack is linear, so a plain stack is
+ * a flat list. Indentation only encodes a genuine fork (a branch with 2+
+ * children on the PR's line): each child of the fork is indented one level as a
+ * sub-branch head, and that head's own linear sub-stack is indented one level
+ * deeper (and kept flat), so the sub-branches remain visually distinct.
+ */
 function buildBranchTree({
   context,
-  currentBranches,
+  branch,
   prBranch,
-  currentDepth,
+  depth,
+  isForkHead,
 }: {
   context: TContext;
-  currentBranches: string[];
+  branch: string;
   prBranch: string;
-  currentDepth: number;
+  depth: number;
+  isForkHead: boolean;
 }): string {
-  let tree = '';
+  const leaf = buildLeaf({ context, branch, depth, prBranch });
 
-  for (const branch of currentBranches) {
-    if (
-      branch !== prBranch &&
-      !(
-        // If we aren't on the last branch,
-        // then we should print it if the pr branch is either a parent or child
-        // of the current branch being looked at in our recursive algorithm
-        (
-          isParentOfBranch(context, branch, prBranch) ||
-          isParentOfBranch(context, prBranch, branch)
-        )
-      )
-    ) {
-      continue;
-    }
+  const children = context.engine
+    .getChildren(branch)
+    .filter((child) => isOnPrLine(context, child, prBranch));
 
-    const leaf = buildLeaf({
-      context,
-      branch,
-      depth: currentDepth,
-      prBranch,
-    });
-
-    tree += leaf || '';
-
-    const children = context.engine.getChildren(branch);
-
-    if (children.length) {
-      tree += `${buildBranchTree({
-        context,
-        currentBranches: children,
-        prBranch,
-        currentDepth: currentDepth + 1,
-      })}`;
-    }
+  if (children.length === 0) {
+    return leaf;
   }
 
-  return tree;
+  // A fork opens a nested level for its sub-branch heads; a linear step keeps
+  // the current level, except the first step off a fork head, which indents the
+  // head's sub-stack once so it reads as belonging to that head.
+  const isFork = children.length > 1;
+  const childDepth = isFork || isForkHead ? depth + 1 : depth;
+
+  const childTrees = children.map((child) =>
+    buildBranchTree({
+      context,
+      branch: child,
+      prBranch,
+      depth: childDepth,
+      isForkHead: isFork,
+    })
+  );
+
+  return `${leaf}${childTrees.join('')}`;
 }
 
 function buildLeaf({
@@ -80,13 +77,11 @@ function buildLeaf({
   branch: string;
   depth: number;
   prBranch: string;
-}): string | undefined {
-  const prInfo = context.engine.getPrInfo(branch);
-
-  const number = prInfo?.number;
+}): string {
+  const number = context.engine.getPrInfo(branch)?.number;
 
   if (!number) {
-    return;
+    return '';
   }
 
   return `\n${'  '.repeat(depth)}* **PR #${number}**${
@@ -105,6 +100,19 @@ function findTerminalParent(context: TContext, currentBranch: string): string {
   }
 
   return findTerminalParent(context, parent);
+}
+
+/** True if `branch` is the PR branch, or an ancestor or descendant of it. */
+function isOnPrLine(
+  context: TContext,
+  branch: string,
+  prBranch: string
+): boolean {
+  return (
+    branch === prBranch ||
+    isParentOfBranch(context, branch, prBranch) ||
+    isParentOfBranch(context, prBranch, branch)
+  );
 }
 
 function isParentOfBranch(

--- a/apps/cli/src/actions/delete_branch.ts
+++ b/apps/cli/src/actions/delete_branch.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { TContext } from '../lib/context';
 import { SCOPE } from '../lib/engine/scope_spec';
 import { ExitFailedError } from '../lib/errors';
+import { preserveMergedAncestors } from './merged_ancestors';
 import { restackBranches } from './restack';
 
 export function deleteBranchAction(
@@ -27,6 +28,11 @@ export function deleteBranchAction(
   const branchesToRestack = context.engine.getRelativeStack(
     args.branchName,
     SCOPE.UPSTACK_EXCLUSIVE
+  );
+  preserveMergedAncestors(
+    context.engine.getChildren(args.branchName),
+    [args.branchName],
+    context
   );
   context.engine.deleteBranch(args.branchName);
   context.splog.info(`Deleted branch ${chalk.red(args.branchName)}`);

--- a/apps/cli/src/actions/fold_branch.ts
+++ b/apps/cli/src/actions/fold_branch.ts
@@ -1,12 +1,18 @@
 import chalk from 'chalk';
 import { TContext } from '../lib/context';
 import { SCOPE } from '../lib/engine/scope_spec';
+import { preserveMergedAncestors } from './merged_ancestors';
 import { restackBranches } from './restack';
 
 export function foldCurrentBranch(keep: boolean, context: TContext): void {
   const currentBranchName = context.engine.currentBranchPrecondition;
   const parentBranchName =
     context.engine.getParentPrecondition(currentBranchName);
+  preserveMergedAncestors(
+    [keep ? currentBranchName : parentBranchName],
+    [keep ? parentBranchName : currentBranchName],
+    context
+  );
   context.engine.foldCurrentBranch(keep);
   if (keep) {
     context.splog.info(

--- a/apps/cli/src/actions/merged_ancestors.ts
+++ b/apps/cli/src/actions/merged_ancestors.ts
@@ -1,0 +1,51 @@
+import { TContext } from '../lib/context';
+
+/**
+ * Forwards merged-ancestor history from branches leaving a stack onto the
+ * survivors that take their place, so PR footers keep showing PRs that landed.
+ * Only branches that actually merged contribute their own PR number; abandoned
+ * (closed/empty) branches still forward any history they had accumulated.
+ *
+ * `removed` should be ordered trunk-side first. Safe to call with no survivors
+ * or nothing to inherit (no-op).
+ */
+export function preserveMergedAncestors(
+  survivors: string[],
+  removed: string[],
+  context: TContext
+): void {
+  const inherited: number[] = [];
+  for (const branch of removed) {
+    const prInfo = context.engine.getPrInfo(branch);
+    inherited.push(...(prInfo?.mergedStackAncestors ?? []));
+    if (prInfo?.number !== undefined && isLandedMerge(branch, context)) {
+      inherited.push(prInfo.number);
+    }
+  }
+
+  if (inherited.length === 0) {
+    return;
+  }
+
+  for (const survivor of survivors) {
+    const existing =
+      context.engine.getPrInfo(survivor)?.mergedStackAncestors ?? [];
+    context.engine.upsertPrInfo(survivor, {
+      mergedStackAncestors: [...new Set([...inherited, ...existing])],
+    });
+  }
+}
+
+function isLandedMerge(branch: string, context: TContext): boolean {
+  const state = context.engine.getPrInfo(branch)?.state;
+  if (state === 'CLOSED') {
+    return false;
+  }
+  if (state === 'MERGED') {
+    return true;
+  }
+  return (
+    !context.engine.isBranchEmpty(branch) &&
+    context.engine.isMergedIntoTrunk(branch)
+  );
+}

--- a/apps/cli/src/actions/sync/clean_branches.ts
+++ b/apps/cli/src/actions/sync/clean_branches.ts
@@ -1,6 +1,7 @@
 import { default as chalk } from 'chalk';
 import { TContext } from '../../lib/context';
 import { deleteBranchAction, isSafeToDelete } from '../delete_branch';
+import { preserveMergedAncestors } from '../merged_ancestors';
 
 /**
  * This method is assumed to be idempotent -- if a merge conflict interrupts
@@ -87,16 +88,25 @@ export async function cleanBranches(
       // We know this branch isn't being deleted.
       // If its parent IS being deleted, we have to change its parent.
 
-      // First, find the nearest ancestor that isn't being deleted.
+      // First, find the nearest ancestor that isn't being deleted, recording
+      // the deleted branches we skip so we can preserve any that merged.
       const parentBranchName = context.engine.getParentPrecondition(branchName);
       let newParentBranchName = parentBranchName;
+      const removedChain: string[] = [];
       while (newParentBranchName in branchesToDelete) {
+        removedChain.push(newParentBranchName);
         newParentBranchName =
           context.engine.getParentPrecondition(newParentBranchName);
       }
 
       // If the nearest ancestor is not already the parent, we make it so.
       if (newParentBranchName !== parentBranchName) {
+        // removedChain is child->trunk; preserve trunk-side first.
+        preserveMergedAncestors(
+          [branchName],
+          [...removedChain].reverse(),
+          context
+        );
         context.engine.setParent(branchName, newParentBranchName);
         context.splog.info(
           `Set parent of ${chalk.cyan(branchName)} to ${chalk.blueBright(

--- a/apps/cli/src/lib/engine/engine.ts
+++ b/apps/cli/src/lib/engine/engine.ts
@@ -606,7 +606,7 @@ export function composeEngine({
       }
       updateMeta(branchName, {
         ...meta,
-        prInfo: {},
+        prInfo: { mergedStackAncestors: meta.prInfo?.mergedStackAncestors },
       });
     },
     getChildren,
@@ -650,7 +650,12 @@ export function composeEngine({
         assertBranchIsValidAndNotTrunkAndGetMeta(currentBranchName);
 
       git.moveBranch(branchName);
-      updateMeta(branchName, { ...cachedMeta, prInfo: {} });
+      updateMeta(branchName, {
+        ...cachedMeta,
+        prInfo: {
+          mergedStackAncestors: cachedMeta.prInfo?.mergedStackAncestors,
+        },
+      });
 
       cachedMeta.children.forEach((childBranchName) =>
         setParent(childBranchName, branchName)

--- a/apps/cli/src/lib/engine/engine.ts
+++ b/apps/cli/src/lib/engine/engine.ts
@@ -813,7 +813,14 @@ export function composeEngine({
           parentBranchName: lastBranch.name,
           parentBranchRevision: lastBranch.revision,
           children: [],
-          prInfo: branchName === branchToSplit ? cachedMeta.prInfo : undefined,
+          prInfo:
+            branchName === branchToSplit
+              ? cachedMeta.prInfo
+              : idx === 0
+              ? {
+                  mergedStackAncestors: cachedMeta.prInfo?.mergedStackAncestors,
+                }
+              : undefined,
         });
         lastBranch.name = branchName;
         lastBranch.revision = branchRevision;

--- a/apps/cli/src/lib/engine/metadata_ref.ts
+++ b/apps/cli/src/lib/engine/metadata_ref.ts
@@ -23,6 +23,7 @@ export const prInfoSchema = t.shape({
     ])
   ),
   isDraft: t.optional(t.boolean),
+  mergedStackAncestors: t.optional(t.array(t.number)),
 });
 export type TBranchPRInfo = t.TypeOf<typeof prInfoSchema>;
 

--- a/apps/cli/test/actions/create_pr_body_footer.test.ts
+++ b/apps/cli/test/actions/create_pr_body_footer.test.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+import { TContext } from '../../src/lib/context';
+import {
+  createPrBodyFooter,
+  footerFooter,
+  footerTitle,
+} from '../../src/actions/create_pr_body_footer';
+
+const TRUNK = 'main';
+
+/**
+ * Builds a minimal fake context whose engine answers the four methods the
+ * footer relies on, derived from a branch -> parent map. Every non-trunk
+ * branch gets a PR number equal to its position in `parents` insertion order
+ * plus 100, unless overridden.
+ */
+function fakeContext(parents: Record<string, string>): TContext {
+  const branches = Object.keys(parents);
+  const prNumber = (branch: string) => 100 + branches.indexOf(branch);
+
+  const engine = {
+    isTrunk: (branch: string) => branch === TRUNK,
+    getParent: (branch: string) => parents[branch],
+    getChildren: (branch: string) =>
+      branches.filter((b) => parents[b] === branch),
+    getPrInfo: (branch: string) =>
+      branch === TRUNK ? undefined : { number: prNumber(branch) },
+  };
+
+  return { engine } as unknown as TContext;
+}
+
+/** Extracts the tree body between the footer's title and trailing signature. */
+function treeOf(footer: string): string {
+  return footer
+    .slice(footerTitle.length, footer.length - footerFooter.length)
+    .replace(/^\n/, '');
+}
+
+describe('createPrBodyFooter', () => {
+  it('renders a linear stack as a flat list', () => {
+    // main -> a -> b -> c, PR on b
+    const context = fakeContext({ a: TRUNK, b: 'a', c: 'b' });
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(
+      ['* **PR #100**', '* **PR #101** 👈', '* **PR #102**'].join('\n')
+    );
+  });
+
+  it('does not indent a single-child descendant', () => {
+    // main -> a -> b, PR on a
+    const context = fakeContext({ a: TRUNK, b: 'a' });
+
+    const tree = treeOf(createPrBodyFooter(context, 'a'));
+
+    expect(tree).to.equal(['* **PR #100** 👈', '* **PR #101**'].join('\n'));
+  });
+
+  it('indents each sub-branch at a genuine fork', () => {
+    // main -> x, x -> y -> z, x -> m -> n, PR on x
+    const context = fakeContext({
+      x: TRUNK,
+      y: 'x',
+      z: 'y',
+      m: 'x',
+      n: 'm',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'x'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '  * **PR #101**',
+        '    * **PR #102**',
+        '  * **PR #103**',
+        '    * **PR #104**',
+      ].join('\n')
+    );
+  });
+
+  it('keeps a linear sub-stack below a fork flat (no staircase within a branch)', () => {
+    // main -> x, x -> y -> z -> z2, x -> m, PR on x
+    const context = fakeContext({
+      x: TRUNK,
+      y: 'x',
+      z: 'y',
+      z2: 'z',
+      m: 'x',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'x'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '  * **PR #101**',
+        '    * **PR #102**',
+        '    * **PR #103**',
+        '  * **PR #104**',
+      ].join('\n')
+    );
+  });
+
+  it('flattens the ancestor spine, indenting only at a downstream fork', () => {
+    // main -> a -> b, b -> c, b -> d, PR on a
+    const context = fakeContext({
+      a: TRUNK,
+      b: 'a',
+      c: 'b',
+      d: 'b',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'a'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '* **PR #101**',
+        '  * **PR #102**',
+        '  * **PR #103**',
+      ].join('\n')
+    );
+  });
+});

--- a/apps/cli/test/actions/create_pr_body_footer.test.ts
+++ b/apps/cli/test/actions/create_pr_body_footer.test.ts
@@ -9,14 +9,27 @@ import {
 const TRUNK = 'main';
 
 /**
- * Builds a minimal fake context whose engine answers the four methods the
- * footer relies on, derived from a branch -> parent map. Every non-trunk
- * branch gets a PR number equal to its position in `parents` insertion order
- * plus 100, unless overridden.
+ * Builds a minimal fake context whose engine answers the methods the footer
+ * relies on, derived from a branch -> parent map. Every non-trunk branch gets
+ * a PR number equal to its position in `parents` insertion order plus 100,
+ * unless overridden. `merged` maps a branch to the PR numbers it carries in
+ * `mergedStackAncestors`.
  */
-function fakeContext(parents: Record<string, string>): TContext {
+function fakeContext(
+  parents: Record<string, string>,
+  merged: Record<string, number[]> = {}
+): TContext {
   const branches = Object.keys(parents);
   const prNumber = (branch: string) => 100 + branches.indexOf(branch);
+
+  const ancestors = (branch: string): string[] => {
+    const parent = parents[branch];
+    return !parent || parent === TRUNK ? [] : [parent, ...ancestors(parent)];
+  };
+  const descendants = (branch: string): string[] =>
+    branches
+      .filter((b) => parents[b] === branch)
+      .flatMap((child) => [child, ...descendants(child)]);
 
   const engine = {
     isTrunk: (branch: string) => branch === TRUNK,
@@ -24,7 +37,14 @@ function fakeContext(parents: Record<string, string>): TContext {
     getChildren: (branch: string) =>
       branches.filter((b) => parents[b] === branch),
     getPrInfo: (branch: string) =>
-      branch === TRUNK ? undefined : { number: prNumber(branch) },
+      branch === TRUNK
+        ? undefined
+        : { number: prNumber(branch), mergedStackAncestors: merged[branch] },
+    getRelativeStack: (branch: string) => [
+      ...ancestors(branch),
+      branch,
+      ...descendants(branch),
+    ],
   };
 
   return { engine } as unknown as TContext;
@@ -123,5 +143,63 @@ describe('createPrBodyFooter', () => {
         '  * **PR #103**',
       ].join('\n')
     );
+  });
+
+  it('renders merged ancestors struck through above the live stack', () => {
+    // main -> b -> c, PR on b, with #98 and #99 merged below
+    const context = fakeContext({ b: TRUNK, c: 'b' }, { b: [98, 99] });
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(
+      [
+        '* ~~**PR #98**~~ (merged)',
+        '* ~~**PR #99**~~ (merged)',
+        '* **PR #100** 👈',
+        '* **PR #101**',
+      ].join('\n')
+    );
+  });
+
+  it('surfaces merged history stored on a non-terminal branch (reorder-robust)', () => {
+    // main -> a -> b -> c, PR on a, history parked on c (as if reordered)
+    const context = fakeContext({ a: TRUNK, b: 'a', c: 'b' }, { c: [98] });
+
+    const tree = treeOf(createPrBodyFooter(context, 'a'));
+
+    expect(tree).to.equal(
+      [
+        '* ~~**PR #98**~~ (merged)',
+        '* **PR #100** 👈',
+        '* **PR #101**',
+        '* **PR #102**',
+      ].join('\n')
+    );
+  });
+
+  it('dedupes and sorts merged ancestors across the stack', () => {
+    const context = fakeContext(
+      { b: TRUNK, c: 'b' },
+      { b: [99, 98], c: [98] }
+    );
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(
+      [
+        '* ~~**PR #98**~~ (merged)',
+        '* ~~**PR #99**~~ (merged)',
+        '* **PR #100** 👈',
+        '* **PR #101**',
+      ].join('\n')
+    );
+  });
+
+  it('omits the merged prefix when there are none', () => {
+    const context = fakeContext({ b: TRUNK, c: 'b' });
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(['* **PR #100** 👈', '* **PR #101**'].join('\n'));
   });
 });

--- a/apps/cli/test/actions/create_pr_body_footer.test.ts
+++ b/apps/cli/test/actions/create_pr_body_footer.test.ts
@@ -202,4 +202,13 @@ describe('createPrBodyFooter', () => {
 
     expect(tree).to.equal(['* **PR #100** 👈', '* **PR #101**'].join('\n'));
   });
+
+  it('excludes a merged number that is still a live PR number in the stack', () => {
+    // main -> b -> c, PR on b, b's merged history collides with c's live #101
+    const context = fakeContext({ b: TRUNK, c: 'b' }, { b: [101] });
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(['* **PR #100** 👈', '* **PR #101**'].join('\n'));
+  });
 });

--- a/apps/cli/test/actions/merged_ancestors.test.ts
+++ b/apps/cli/test/actions/merged_ancestors.test.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import { TContext } from '../../src/lib/context';
+import { preserveMergedAncestors } from '../../src/actions/merged_ancestors';
+
+type Branch = {
+  number?: number;
+  state?: 'OPEN' | 'CLOSED' | 'MERGED';
+  mergedStackAncestors?: number[];
+  empty?: boolean;
+  inTrunk?: boolean;
+};
+
+function fakeContext(initial: Record<string, Branch>): {
+  context: TContext;
+  read: (branch: string) => number[] | undefined;
+} {
+  const store: Record<string, Branch> = JSON.parse(JSON.stringify(initial));
+  const engine = {
+    getPrInfo: (branch: string) => store[branch],
+    isBranchEmpty: (branch: string) => !!store[branch]?.empty,
+    isMergedIntoTrunk: (branch: string) => !!store[branch]?.inTrunk,
+    upsertPrInfo: (branch: string, patch: Partial<Branch>) => {
+      store[branch] = { ...store[branch], ...patch };
+    },
+  };
+  return {
+    context: { engine } as unknown as TContext,
+    read: (branch) => store[branch]?.mergedStackAncestors,
+  };
+}
+
+describe('preserveMergedAncestors', () => {
+  it('captures a merged ancestor with a PR number', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, state: 'MERGED' },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.deep.equal([100]);
+  });
+
+  it('does not capture a closed ancestor, even if in trunk', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, state: 'CLOSED', inTrunk: true },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.be.undefined;
+  });
+
+  it('does not capture an empty ancestor with a PR number', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, empty: true, inTrunk: true },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.be.undefined;
+  });
+
+  it('captures via the isMergedIntoTrunk fallback (no PR state, non-empty)', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, inTrunk: true },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.deep.equal([100]);
+  });
+
+  it('captures an explicitly MERGED ancestor even if the branch is empty', () => {
+    // The empty guard applies only to the git fallback, not to MERGED state.
+    const { context, read } = fakeContext({
+      a: { number: 100, state: 'MERGED', empty: true },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.deep.equal([100]);
+  });
+
+  it('forwards an abandoned ancestor\'s history but not its own number', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, state: 'CLOSED', mergedStackAncestors: [98] },
+      b: {},
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.deep.equal([98]);
+  });
+
+  it('dedupes against the survivor\'s existing list', () => {
+    const { context, read } = fakeContext({
+      a: { number: 100, state: 'MERGED' },
+      b: { mergedStackAncestors: [100] },
+    });
+    preserveMergedAncestors(['b'], ['a'], context);
+    expect(read('b')).to.deep.equal([100]);
+  });
+});

--- a/apps/cli/test/actions/pr_info_preservation.test.ts
+++ b/apps/cli/test/actions/pr_info_preservation.test.ts
@@ -3,6 +3,7 @@ import { BasicScene } from '../lib/scenes/basic_scene';
 import { configureTest } from '../lib/utils/configure_test';
 
 for (const scene of [new BasicScene()]) {
+  // eslint-disable-next-line max-lines-per-function
   describe(`(${scene}): prInfo mergedStackAncestors preservation`, function () {
     configureTest(this, scene);
 
@@ -59,6 +60,111 @@ for (const scene of [new BasicScene()]) {
 
       expect(
         scene.getContext().engine.getPrInfo('b')?.mergedStackAncestors
+      ).to.deep.equal([98]);
+    });
+
+    it('moves merged history to the bottom when a split renames the branch', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('b', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+
+      // Single new branch b2 at HEAD: b is deleted, b2 becomes the new bottom.
+      context.engine.detach();
+      context.engine.applySplitToCommits({
+        branchToSplit: 'b',
+        branchNames: ['b2'],
+        branchPoints: [0],
+      });
+
+      expect(
+        context.engine.getPrInfo('b2')?.mergedStackAncestors
+      ).to.deep.equal([98]);
+    });
+
+    it('keeps merged history when a split retains the original name', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('b', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+
+      // Split into a single branch that keeps the name b: b is retained and
+      // keeps its full prInfo (branchName === branchToSplit branch of the ternary).
+      context.engine.detach();
+      context.engine.applySplitToCommits({
+        branchToSplit: 'b',
+        branchNames: ['b'],
+        branchPoints: [0],
+      });
+
+      const prInfo = context.engine.getPrInfo('b');
+      expect(prInfo?.mergedStackAncestors).to.deep.equal([98]);
+      expect(prInfo?.number).to.equal(100);
+    });
+
+    it('puts merged history only on the bottom of a multi-branch split', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+      scene.repo.createChangeAndCommit('b2'); // second commit on b
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('b', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+
+      // Split b into lower (b's first commit) and upper (HEAD); b renamed away.
+      context.engine.detach();
+      context.engine.applySplitToCommits({
+        branchToSplit: 'b',
+        branchNames: ['lower', 'upper'],
+        branchPoints: [0, 1],
+      });
+
+      expect(
+        context.engine.getPrInfo('lower')?.mergedStackAncestors
+      ).to.deep.equal([98]);
+      expect(context.engine.getPrInfo('upper')?.mergedStackAncestors).to.be
+        .undefined;
+    });
+
+    it('puts merged history on the bottom when a split keeps the name above it', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+      scene.repo.createChangeAndCommit('b2');
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('b', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+
+      // Retain b as the TOP branch; a new branch `lower` is the bottom.
+      context.engine.detach();
+      context.engine.applySplitToCommits({
+        branchToSplit: 'b',
+        branchNames: ['lower', 'b'],
+        branchPoints: [0, 1],
+      });
+
+      expect(
+        context.engine.getPrInfo('lower')?.mergedStackAncestors
       ).to.deep.equal([98]);
     });
   });

--- a/apps/cli/test/actions/pr_info_preservation.test.ts
+++ b/apps/cli/test/actions/pr_info_preservation.test.ts
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { BasicScene } from '../lib/scenes/basic_scene';
+import { configureTest } from '../lib/utils/configure_test';
+
+for (const scene of [new BasicScene()]) {
+  describe(`(${scene}): prInfo mergedStackAncestors preservation`, function () {
+    configureTest(this, scene);
+
+    it('clearPrInfo retains mergedStackAncestors', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('a', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+      context.engine.clearPrInfo('a');
+
+      const prInfo = context.engine.getPrInfo('a');
+      expect(prInfo?.mergedStackAncestors).to.deep.equal([98]);
+      expect(prInfo?.number).to.be.undefined;
+    });
+
+    it('renameCurrentBranch retains mergedStackAncestors', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+
+      const context = scene.getContext();
+      context.engine.upsertPrInfo('a', {
+        number: 100,
+        mergedStackAncestors: [98],
+      });
+      context.engine.renameCurrentBranch('a2');
+
+      expect(
+        context.engine.getPrInfo('a2')?.mergedStackAncestors
+      ).to.deep.equal([98]);
+    });
+
+    it('persists mergedStackAncestors through a setParent + reload (engine-level)', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      // Persist the field (upsert writes the metadata ref immediately).
+      scene
+        .getContext()
+        .engine.upsertPrInfo('b', { number: 100, mergedStackAncestors: [98] });
+
+      // A fresh context reloads from refs; reparent b onto trunk — the same
+      // updateMeta write path that move/reorder/restack go through. This is an
+      // engine-level persistence guard for the "preserved through updateMeta +
+      // reload" claim; it passes once Task 1's schema field exists (not a
+      // red-first case). The user-facing removal flows are exercised at the
+      // command level by the `repo sync` tests in Task 4.
+      scene.getContext().engine.setParent('b', scene.getContext().engine.trunk);
+
+      expect(
+        scene.getContext().engine.getPrInfo('b')?.mergedStackAncestors
+      ).to.deep.equal([98]);
+    });
+  });
+}

--- a/apps/cli/test/commands/branch/branch_delete.test.ts
+++ b/apps/cli/test/commands/branch/branch_delete.test.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 import { allScenes } from '../../lib/scenes/all_scenes';
+import {
+  readMetadataRef,
+  writeMetadataRef,
+} from '../../../src/lib/engine/metadata_ref';
 import { configureTest } from '../../lib/utils/configure_test';
 import { expectBranches } from '../../lib/utils/expect_branches';
 
@@ -17,6 +21,40 @@ for (const scene of allScenes) {
       scene.repo.checkoutBranch('main');
       scene.repo.runCliCommand([`delete`, branchName, `-f`]);
       expectBranches(scene.repo, 'main');
+    });
+
+    it('preserves a merged branch in its child when deleted manually', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: { number: 100, state: 'MERGED' },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`delete`, `a`, `-f`]);
+
+      expect(
+        readMetadataRef('b', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([100]);
+    });
+
+    it('does not preserve an unmerged branch deleted manually', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      scene.repo.runCliCommand([`delete`, `a`, `-f`]);
+
+      expect(readMetadataRef('b', scene.dir).prInfo?.mergedStackAncestors).to.be
+        .undefined;
     });
   });
 }

--- a/apps/cli/test/commands/branch/branch_fold.test.ts
+++ b/apps/cli/test/commands/branch/branch_fold.test.ts
@@ -3,6 +3,10 @@ import { allScenes } from '../../lib/scenes/all_scenes';
 import { configureTest } from '../../lib/utils/configure_test';
 import { expectBranches } from '../../lib/utils/expect_branches';
 import { expectCommits } from '../../lib/utils/expect_commits';
+import {
+  readMetadataRef,
+  writeMetadataRef,
+} from '../../../src/lib/engine/metadata_ref';
 
 for (const scene of allScenes) {
   describe(`(${scene}): fold`, function () {
@@ -75,6 +79,58 @@ for (const scene of allScenes) {
 
       scene.repo.checkoutBranch('d');
       expectCommits(scene.repo, 'd, b, a, 1');
+    });
+
+    it('forwards merged history to the survivor (keep=false)', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      writeMetadataRef(
+        'b',
+        {
+          ...readMetadataRef('b', scene.dir),
+          prInfo: {
+            ...readMetadataRef('b', scene.dir).prInfo,
+            mergedStackAncestors: [98],
+          },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`fold`]); // b absorbed into a; a survives
+
+      expect(
+        readMetadataRef('a', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([98]);
+    });
+
+    it('forwards merged history to the survivor (keep=true)', () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      // Parent a carries the merged ancestor; folding with --keep keeps b,
+      // which must inherit a's history.
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: {
+            ...readMetadataRef('a', scene.dir).prInfo,
+            mergedStackAncestors: [98],
+          },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`fold`, `--keep`]); // a absorbed into b; b survives
+
+      expect(
+        readMetadataRef('b', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([98]);
     });
   });
 }

--- a/apps/cli/test/commands/repo/sync.test.ts
+++ b/apps/cli/test/commands/repo/sync.test.ts
@@ -166,5 +166,125 @@ for (const scene of allScenes) {
       expect(metadata.includes('b')).to.be.false;
       expect(metadata.includes('c')).to.be.true;
     });
+
+    it('preserves a merged ancestor PR number on the reparented child', async () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: { number: 100, state: 'MERGED' },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`repo`, `owner`]);
+      scene.repo.runCliCommand([`repo`, `sync`, `-f`, `--no-pull`]);
+
+      expectBranches(scene.repo, 'b, main');
+      expect(
+        readMetadataRef('b', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([100]);
+    });
+
+    it('does not preserve a closed (unmerged) ancestor', async () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: { number: 100, state: 'CLOSED' },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`repo`, `owner`]);
+      scene.repo.runCliCommand([`repo`, `sync`, `-f`, `--no-pull`]);
+
+      expectBranches(scene.repo, 'b, main');
+      expect(readMetadataRef('b', scene.dir).prInfo?.mergedStackAncestors).to
+        .be.undefined;
+    });
+
+    it('captures both branches when two merge in one sync', async () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+      scene.repo.createChange('4', 'c');
+      scene.repo.runCliCommand([`create`, `c`, `-m`, `c`]);
+
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: { number: 100, state: 'MERGED' },
+        },
+        scene.dir
+      );
+      writeMetadataRef(
+        'b',
+        {
+          ...readMetadataRef('b', scene.dir),
+          prInfo: { number: 101, state: 'MERGED' },
+        },
+        scene.dir
+      );
+
+      scene.repo.runCliCommand([`repo`, `owner`]);
+      scene.repo.runCliCommand([`repo`, `sync`, `-f`, `--no-pull`]);
+
+      expectBranches(scene.repo, 'c, main');
+      expect(
+        readMetadataRef('c', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([100, 101]);
+    });
+
+    it('chains merged ancestors across successive syncs', async () => {
+      scene.repo.createChange('2', 'a');
+      scene.repo.runCliCommand([`create`, `a`, `-m`, `a`]);
+      scene.repo.createChange('3', 'b');
+      scene.repo.runCliCommand([`create`, `b`, `-m`, `b`]);
+      scene.repo.createChange('4', 'c');
+      scene.repo.runCliCommand([`create`, `c`, `-m`, `c`]);
+
+      writeMetadataRef(
+        'a',
+        {
+          ...readMetadataRef('a', scene.dir),
+          prInfo: { number: 100, state: 'MERGED' },
+        },
+        scene.dir
+      );
+      scene.repo.runCliCommand([`repo`, `owner`]);
+      scene.repo.runCliCommand([`repo`, `sync`, `-f`, `--no-pull`]);
+
+      writeMetadataRef(
+        'b',
+        {
+          ...readMetadataRef('b', scene.dir),
+          prInfo: {
+            ...readMetadataRef('b', scene.dir).prInfo,
+            number: 101,
+            state: 'MERGED',
+          },
+        },
+        scene.dir
+      );
+      scene.repo.runCliCommand([`repo`, `sync`, `-f`, `--no-pull`]);
+
+      expectBranches(scene.repo, 'c, main');
+      expect(
+        readMetadataRef('c', scene.dir).prInfo?.mergedStackAncestors
+      ).to.deep.equal([100, 101]);
+    });
   });
 }


### PR DESCRIPTION
Fixes #139.

## Problem

The PR **Dependency Tree** footer is rebuilt from the live local branch graph. When the bottom PR of a stack merges and `ch sync` removes its branch, every surviving PR's footer regenerates with no trace of the merged PR — over a long stack, each footer shrinks with every merge. Upstream Graphite preserves this history; charcoal regressed it.

## Approach

Persist merged ancestors' PR numbers in the surviving branch's `prInfo.mergedStackAncestors`, and union them across the live stack at footer-render time so the history shows regardless of which branch holds it (robust to `move`/`reorder`).

- **Schema:** `mergedStackAncestors?: number[]` on `prInfoSchema` (rides through the load-time metadata rewrites that a top-level field would not).
- **Capture:** a shared `preserveMergedAncestors` helper wired into the three action sites where a branch leaves a stack (`sync`, `delete`, `fold`); `split` is handled in the engine (`applySplitToCommits`). Only genuinely-landed merges contribute their own number; abandoned branches still forward accumulated history.
- **Render:** merged ancestors render as `* ~~**PR #N**~~ (merged)`, deduped and sorted ascending, above the live tree.
- **Preservation:** `clearPrInfo` and `renameCurrentBranch` retain the field across their `prInfo` reset.
- **Non-goals:** `ch pop`/unbranch and `untrack` intentionally discard it.

## Testing

Full suite green (264 passing), `yarn lint` and `yarn check` clean. New/extended coverage for the capture helper, footer render (union/dedupe/sort/reorder-robustness/collision-exclusion), sync/delete/fold wiring, `clearPrInfo`/rename retention, and split.

---

Stacked on #141 (this PR is opened against `main`, so its diff includes #141's flat-list commit until that merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)